### PR TITLE
set visited link color to default blue

### DIFF
--- a/themes/startwords/assets/scss/style.scss
+++ b/themes/startwords/assets/scss/style.scss
@@ -22,6 +22,9 @@ a.title:visited {text-decoration: none;}
 a.title:link {text-decoration: none;}
 a.title:active {text-decoration: none;}
 
+// use default blue link color for visited links
+*:visited { color: rgb(0, 0, 238); }
+
 .arrow {
   border-left: 1px dotted;
   height: 875px;


### PR DESCRIPTION
fixes #9 

uses the [`:visited` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited) to set the color for visited links to `rgb(0, 0, 238)`, which appears to be the current default in chrome/ff/safari.

i got curious and did look at vendor-prefixed values like [`-moz-hyperlinktext`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Mozilla_Color_Preference_Extensions), which works great in firefox, but apparently the webkit version [`-webkit-link`](https://stackoverflow.com/a/42573062/12678195) will still give you purple if the link was visited, so there isn't really a way to say "give me whatever color the browser would _normally_ use for an un-visited link" across all browsers.
