### PR TITLE
Add 3D embed shortcode for sketchfab

### DIFF
--- a/content/issues/1/data_beyond_vision.md
+++ b/content/issues/1/data_beyond_vision.md
@@ -66,6 +66,9 @@ We invite you to participate in the labor of data work. Download models and inst
 
 ## Folding in the Non-Famous Members of the Shakespeare and Company Library
 
+{{<sketchfab id="9c96fadd27c34a11902f0a1281ea0ab4"
+    title="Shakespeare and Company membership origami">}}
+
 ### Goal
 
 The Shakespeare and Company library is most often known by its famous members — the writers of the Lost Generation and their friends. We wanted to highlight the activity of the relatively unknown members — frequently women - who in fact represent a much larger portion of the library's day-to-day activity and thus arguably better represent it. The piece makes use of unit origami to create a larger, cohesive form from small folded units, mirroring the relationship between a single member and the greater bulk of the library.
@@ -87,6 +90,9 @@ Nick Budak, Xinyi Li
 ----
 
 ## Modeling Shakespeare and Company Library Membership
+
+{{<sketchfab id="89985d66f7244d87b7edbe5fd6266f0d"
+    title="Shakespeare and Company membership lollipop chart">}}
 
 ### Goal
 

--- a/themes/startwords/assets/scss/_global.scss
+++ b/themes/startwords/assets/scss/_global.scss
@@ -115,5 +115,11 @@ h1, h2, h3, h4, h5, h6 {
     font-family: $font-sans;
 }
 
+// sketchfab embedding
+.sketchfab-embed-wrapper > iframe {
+    width: 100%;
+    height: 320px;
+}
+
 // use default blue link color for visited links
 // *:visited { color: rgb(0, 0, 238); }

--- a/themes/startwords/layouts/shortcodes/sketchfab.html
+++ b/themes/startwords/layouts/shortcodes/sketchfab.html
@@ -1,0 +1,11 @@
+{{/* Shortcode for Sketchfab 3D object embedding  */}}
+<div class="sketchfab-embed-wrapper">
+    <iframe
+        title="{{ .Get `title` }} on Sketchfab"
+        frameborder="0"
+        allow="autoplay; fullscreen; vr"
+        mozallowfullscreen="true"
+        webkitallowfullscreen="true"
+        src="https://sketchfab.com/models/{{ .Get `id` }}/embed?autospin=0.2&amp;autostart=0&amp;camera=0&amp;preload=1&amp;ui_controls=1&amp;ui_infos=1&amp;ui_inspector=1&amp;ui_stop=1&amp;ui_watermark=1&amp;ui_watermark_link=1">
+    </iframe>
+</div>


### PR DESCRIPTION
- defines a `sketchfab` shortcode (uses default values for stuff like autoplay, but we could add more customization if we want)
- preliminary style for generated iframe
- uses shortcode in data beyond vision article