### PR TITLE
testing article preview wrapping solution

### DIFF
--- a/content/issues/1/_index.md
+++ b/content/issues/1/_index.md
@@ -8,4 +8,4 @@ date: 2020-01-01
 slug: 1
 ---
 
-Data Transformations are marshmallow cotton candy candy candy canes icing toffee apple pie jujubes. Tart cotton candy danish soufflé gummies. Wafer sesame snaps cheesecake pie tootsie roll jujubes caramels jelly cake. Ice cream chocolate cake dessert. Chocolate cake cake jelly croissant pudding muffin croissant lollipop. Cookie brownie jelly-o tootsie roll dessert candy canes. Macaroon gummi bears chocolate bar ice cream gingerbread apple pie halvah.
+Data Transformations are marshmallow cotton candy candy candy canes icing toffee apple pie jujubes. Tart cotton candy danish soufflé gummies. Wafer sesame snaps cheesecake pie tootsie roll jujubes caramel. jelly cake. Ice cream chocolate cake dessert. Chocolate cake cake jelly croissant pudding muffin croissant lollipop. Cookie brownie jelly-o tootsie roll dessert candy canes. Macaroon gummi bears chocolate bar ice cream gingerbread apple pie halvah.

--- a/content/issues/1/body-as-data/index.md
+++ b/content/issues/1/body-as-data/index.md
@@ -7,7 +7,9 @@ authors:
 date: 2020-01-01
 doi: 10.5281/zenodo.3713678
 ---
-When I was growing up I liked to read about dying children. I’m not talking about the Victorian orphan kind of dying either, not the dying of storybooks, but children (well, teenagers) who were terminally ill.
+It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it REally l kinds of chronic illnesses (cystic fibrosis, hemophilia, diabetes) as well as the untimely death of loved ones from causes including suicide. They were books about grief and communities formed in times of crisis.
+These books would have been perfect for a buddi
+
 <!--more-->
 I was twelve and fixated on books written by an author with the implausible name of Lurlene McDaniel. The first book I encountered was Six Months to Live, which chronicled the life a popular teenager in the wake of her diagnosis with leukemia. McDaniel’s characters didn’t just have cancer; they wrestled with all kinds of chronic illnesses (cystic fibrosis, hemophilia, diabetes) as well as the untimely death of loved ones from causes including suicide. They were books about grief and communities formed in times of crisis.
 These books would have been perfect for a budding hypochondriac, or for a reader given to purple prose and melodrama, but I read them for the medical details, taking mental notes on how to diagnose various signs and symptoms and stockpiling already-outdated knowledge about treatment options. Rather than imagining myself as the protagonist, I occupied the position of the doctor. If this sounds like a perfect setup for attending medical school, it was. I didn’t, but that’s a different story. It turned out, though, that I’d would have to be the protagonist anyway.

--- a/content/issues/1/data-beyond-vision/index.md
+++ b/content/issues/1/data-beyond-vision/index.md
@@ -12,7 +12,7 @@ doi: 10.5281/zenodo.3713671
 ---
 
 
-How do we share tangible objects in a visual medium? We present, describe, use words, pictures, diagrams, _show_ … fail.
+Data Transformations are marshmallow cotton candy candy candy canes icing toffee apple pie jujubes. Tart cotton candy danish soufflé gummies. Wafer sesame snaps cheesecake pie tootsie roll jujubes caramels jelly cake. Ice cream chocolate cake dessert. Chocolate cake cake jelly croissant pudding muffin croissant lollipop.
 
 <!--more-->
 

--- a/themes/startwords/assets/scss/article/_global.scss
+++ b/themes/startwords/assets/scss/article/_global.scss
@@ -3,8 +3,8 @@
 // variables
 $frame-height: rem(320px);
 
-$triangle-left: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 200% 50%);
-$triangle-right: polygon(100% 0%, 0% 0%, 0% 100%, 100% 100%, -100% 50%);
+$triangle-left: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 300% 50%);
+$triangle-right: polygon(100% 0%, 0% 0%, 0% 100%, 100% 100%, -200% 50%);
 
 // $triangle-left: polygon(0% 0%, 100% 0%, 100% 100%);
 // $triangle-right: polygon(0% 100%, 0% 0%, 100% 0%);

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -10,11 +10,15 @@
     a:not(.doi) { text-decoration: none; }
 
     p {
+        margin: 0;
+        overflow: hidden;
+        height: 275px;
         line-height: rem(22px);
         position: relative;
     }
 
     h2 {
+        margin: 0;
         font-family: $font-sans;
         font-weight: bold;
         font-style: italic;
@@ -34,22 +38,18 @@
 
     // background text
     .bg-text {
+        overflow: hidden;
         position: absolute;
-        width: 48vw;
+        width: 50vw;
+        height: 500px;
         color: rgba(224, 206, 255, 0.05);
-        top: rem(-25px);
+        top: rem(-50px);
         font-size: rem(20px);
 
         @media (min-width: $breakpoint-s) {
             font-size: rem(30px);
-            top: rem(-50px);
+            top: rem(-100px);
         }
-    }
-
-    // hyphenation
-    p, .bg-text {
-        word-wrap: anywhere;
-        hyphens: auto;
     }
 
     // text-shaping elements
@@ -57,8 +57,10 @@
     p::before {
         content: '';
         width: 100%;
-        height: 300px;
     }
+
+    .bg-text::before { height: 500px; }
+    p::before { height: 275px; }
 
     // left/first preview
     &:first-of-type {
@@ -76,9 +78,6 @@
             shape-outside: $triangle-left;
         }
 
-        // create space for arrow movement
-        h2 { margin-right: rem(-10px); }
-
         // red arrow
         h2::after {
             content: url('/link-arrow-right.svg');
@@ -93,7 +92,7 @@
     &:last-of-type {
         float: right;
         text-align: right;
-        margin-top: rem(40px);
+        margin-top: rem(60px);
 
         .bg-text {
             left: 0;
@@ -104,9 +103,6 @@
             float: left;
             shape-outside: $triangle-right;
         }
-
-        // create space for arrow movement
-        h2 { margin-left: rem(-10px); }
 
         // red arrow
         h2::before {

--- a/themes/startwords/layouts/article/summary.html
+++ b/themes/startwords/layouts/article/summary.html
@@ -1,7 +1,14 @@
 <article class="article-summary">
-    <div class="bg-text" role="presentation">{{ .Summary | plainify }}</div>
+    {{ with .Summary | plainify | htmlUnescape }}
+    <div class="bg-text" role="presentation">{{- substr . 0 210 -}}</div>
+    {{ end }}
     <a href="{{ .Permalink }}">
-        <p>{{ .Summary | plainify }}</p>
+        {{ with .Summary | plainify | htmlUnescape }}
+        <p>
+            {{- substr . 0 210 -}}
+            {{ if gt (len .) 210 }}…{{ end }}
+        </p>
+        {{ end }}
         <h2>{{ .Title }}</h2>
     </a>
     {{ partial "authors" . }}


### PR DESCRIPTION
opening so I can get some help with this, since I'm running out of options to try and not sure how to proceed. see comments on #59 for context.

at the moment I'm trying to truncate in the template to a set number of characters and append an ellipsis if the text was truncated. the issue is that if the ellipsis comes at the end of a word that is outside the text-shape, it will not be shown at all, because the word can't get fit into the shape even though the actual text is within the character limit. `text-overflow: ellipsis` is also no help because it only works in the text flow direction - our content is overflowing the shape vertically (by one line) rather than overflowing horizontally (at the end of the line). you can see the issue in this branch; some content will show the ellipsis but on tablet (for example) it wraps outside the shape and doesn't get shown.

if there's no sane way to do this automatically, we may just have to put the burden of correctly formatting preview content on the writer, with the knowledge that they will have to manually tinker until it looks right.