### PR TITLE
Feature/short pieces

### DIFF
--- a/content/issues/1/body-as-data/index.md
+++ b/content/issues/1/body-as-data/index.md
@@ -1,7 +1,7 @@
 ---
 type: article
 title: The Body As Data
-article_number: 2
+order: 2
 authors:
     - Rebecca Munson
 date: 2020-01-01

--- a/content/issues/1/data-beyond-vision/index.md
+++ b/content/issues/1/data-beyond-vision/index.md
@@ -1,7 +1,7 @@
 ---
 type: article
 title: Data Beyond Vision
-article_number: 1
+order: 1
 authors:
   - Rebecca Sutton Koeser
   - Gissoo Doroudian

--- a/content/issues/1/stack-membership-activities/index.md
+++ b/content/issues/1/stack-membership-activities/index.md
@@ -1,0 +1,34 @@
+---
+type: article
+title: Stack Shakespeare and Company Membership Activities
+order: 6
+authors:
+  - Xinyi Li
+  - Rebecca Sutton Koeser
+tags: [howto]
+---
+
+Create your own kirigami model of Shakespeare and Company lending library membership activities,
+as described in [Data Beyond Vision](/issues/1/data-beyond-vision/#stacking).
+
+## Tools
+* Printer
+* X-acto knife or other blade
+* Bone folder or credit card
+* Cutting matt or old magazines
+
+## Supplies
+* 4 Sheets of card stock paper (letter size is recommended, larger also works)
+* Double-sided tape (optional)
+
+
+## Steps
+1. Download the PDF
+2. Print on cardstock paper at actual size
+3. Cut along the vertical solid lines
+4. Fold along the horizontal dotted lines. Follow the legend for mountain and valley folds.
+5. Set up on a table or shelf
+6. For best results, set on a table against a wall and use double-stick tape to fix to table and wall surface (optional)
+
+**Yield:**  kirigami model of Shakespeare and Company lending library membership activities
+

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -14,6 +14,7 @@ The Startwords Hugo theme is designed for [a journal of the same name](https://s
 - Article DOIs (registered with [Zenodo](zenodo.org/)) are specified in each article's YAML header, so that article metadata can be easily harvested by [Zotero](https://www.zotero.org/) citation management software.
 - Markdown footnotes (`[^1]`) are rendered both as **contextual notes**—a new design feature that allows for popup annotations to float above a referenced line—as well as endnotes at the bottom of an article's page.
 - Article illustration capabilities are built in using [IIIF](https://iiif.io/) for images and [Sketchfab](https://sketchfab.com/) for 3D embeddings.
+- Article order in an issue is determined by `order` page parameter. The first two articles will be displayed as featured essays highlighted side by side on the issue page; all other articles will be listed by title in the order specified.
 
 ## Shortcodes
 

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -150,11 +150,16 @@ $preview-height: rem(250px);
     }
 }
 
+/* non-featured articles in an issue have a briefer listing */
+.article-short-summary {
 
-.other-articles {
     clear: both;
-    padding-top: 2rem;
     font-size: rem(16px);
+    padding-bottom: 0.75em;
+
+    &:first-of-type {
+        padding-top: 2rem;
+    }
 
     a {
         font-weight: normal;

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -149,3 +149,33 @@ $preview-height: rem(250px);
         }
     }
 }
+
+
+.other-articles {
+    clear: both;
+    padding-top: 2rem;
+    font-size: rem(16px);
+
+    a {
+        font-weight: normal;
+    }
+
+    .tag {
+        color: $light-grey;
+        text-transform: uppercase;
+        font-size: rem(12px);
+        &::before {
+            content: "#";
+        }
+    }
+
+    // sequential author display with commas
+    .authors {
+        padding: 0;
+        margin: 0;
+        li, address { display: inline; }
+        address::after { content: ', '; }
+        li:last-child address::after { content: ''; }
+    }
+
+}

--- a/themes/startwords/layouts/article/single.txt
+++ b/themes/startwords/layouts/article/single.txt
@@ -9,19 +9,21 @@
 |
 +----------------------------------------------------------------------------------->
 |
-|  "{{ .Title }}"
+|  {{ .Title }}
 |
 |  Authors:
 |  {{ range .Params.Authors }}
 |     {{ . }}{{ end }}
 |
 |  {{ .Permalink }}
-|
-|  {{ if .Params.doi }}doi:{{ .Params.doi }}{{ end }}
+|{{ if .Params.doi }}
+|  doi:{{ .Params.doi }}{{ end }}
+|{{ if .Params.tags }}
+|  {{ range .Params.tags }}#{{ . }}{{ end }}{{ end }}
 |
 +----------------------------------------------------------------------------------->
 |
-|  Issue {{ .Parent.Params.number }}: {{ .Parent.Params.issue_theme }}
+|  Issue {{ .Parent.Params.number }}: {{ upper .Parent.Params.theme }}
 |  {{ .Parent.Permalink }}
 |  {{ .Parent.Date.Format "January 2006" }}
 |
@@ -29,4 +31,3 @@
 
 {{/* double newlines to put blank lines between paragraphs */}}
 {{ replace .Plain "\n" "\n\n" }}
-

--- a/themes/startwords/layouts/issue/single.html
+++ b/themes/startwords/layouts/issue/single.html
@@ -25,17 +25,15 @@
                 {{ .Render "summary" }}
             {{ end }}
 
-        <div class="other-articles">
         {{ range after 2 (.Pages.ByParam "order") }}
-            <div class="article-short-summary">
-                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-                {{ partial "authors" . }}
-                {{ range .Params.tags }}
-                <span class="tag">{{ . }}</span>
-                {{ end }}
-            </div>
-        {{ end }}
+        <div class="article-short-summary">
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+            {{ partial "authors" . }}
+            {{ range .Params.tags }}
+            <span class="tag">{{ . }}</span>
+            {{ end }}
         </div>
+        {{ end }}
 
     </section>
 

--- a/themes/startwords/layouts/issue/single.html
+++ b/themes/startwords/layouts/issue/single.html
@@ -18,12 +18,28 @@
             </a>
         </div>
     </div>
+
     <section id="features" aria-label="features" class="inverted grid">
         <div class="wide-container">
-            {{ range .Pages }}
-            {{ .Render "summary" }}
+            {{ range first 2 (.Pages.ByParam "order") }}
+                {{ .Render "summary" }}
             {{ end }}
+
+        <div class="other-articles">
+        {{ range after 2 (.Pages.ByParam "order") }}
+            <div class="article-short-summary">
+                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                {{ partial "authors" . }}
+                {{ range .Params.tags }}
+                <span class="tag">{{ . }}</span>
+                {{ end }}
+            </div>
+        {{ end }}
         </div>
+
     </section>
+
+
+
 </main>
 {{ end }}


### PR DESCRIPTION
- adds a draft "short piece" (one of the howtos connected to DBV essay)
- revises single issue template to treat the first two articles in an issue as the featured article, display all others in a simple list; ordering based on page metadata so editor configurable
- list of other articles is based on Gissoo's design but with a few more pieces of information (authors, tags)

I noticed that the lists I'm using in the howto don't work very well in the text output. I fiddled with it a bit but didn't find a solution.