### PR TITLE
Add Google Analytics tracking id and include internal Hugo template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,7 @@ title = "Startwords"
 theme = "startwords"
 copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License."
 enableEmoji = true
+googleAnalytics = "UA-87887700-8"
 
 [taxonomies]
   author = "authors"

--- a/themes/startwords/layouts/_default/baseof.html
+++ b/themes/startwords/layouts/_default/baseof.html
@@ -37,7 +37,7 @@
     {{ $nav := resources.Get "js/nav.js" }}
     {{ $js := slice $notes $nav $issue | resources.Concat "js/bundle.js" | resources.Minify}}
     <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
-
+    {{ template "_internal/google_analytics_async.html" . }}
     <!-- alternative formats -->
     {{ range .AlternativeOutputFormats -}}
     <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">


### PR DESCRIPTION
If we want to configure to only include in production, we could add a check for hugo environment and set it properly when we build and deploy the site (see https://discourse.gohugo.io/t/how-to-exclude-google-analytics-when-running-under-hugo-local-server/6092/7). However, I set up views in Google Analytics to filter based on hostname, so we can see if that is sufficient.