### PR TITLE
add image styles and set up hugo image processing (#111)

### DIFF
--- a/themes/startwords/assets/scss/article/_figure.scss
+++ b/themes/startwords/assets/scss/article/_figure.scss
@@ -1,0 +1,29 @@
+/* figures (images, diagrams) in articles */
+
+body.article figure {
+    margin: rem(30px) 0;
+
+    img {
+        display: block;
+        margin: 0 auto;
+        
+        &.landscape {
+            width: 100%;
+            @media (min-width: $breakpoint-m) {
+                width: calc(100% + 200px);
+                margin-left: rem(-100px);
+                margin-right: rem(-100px);
+            }
+        }
+
+        &.portrait {
+            width: 75%;
+            @media (min-width: $breakpoint-m) { width: 100%; }
+        }
+    }
+
+    figcaption {
+        font-style: italic;
+        font-size: rem(16px);
+    }
+}

--- a/themes/startwords/assets/scss/article/_figure.scss
+++ b/themes/startwords/assets/scss/article/_figure.scss
@@ -1,12 +1,19 @@
 /* figures (images, diagrams) in articles */
 
+// fallback styles for images outside of figures (shouldn't happen)
+body.article .text-container > p > img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+}
+
 body.article figure {
     margin: rem(30px) 0;
 
     img {
         display: block;
         margin: 0 auto;
-        
+
         &.landscape {
             width: 100%;
             @media (min-width: $breakpoint-m) {

--- a/themes/startwords/assets/scss/article/_single.scss
+++ b/themes/startwords/assets/scss/article/_single.scss
@@ -141,8 +141,6 @@ body.article {
         }
     }
     
-    .text-container { overflow: hidden; }
-    
     // embedded content
     .sketchfab-embed-wrapper {
         margin: rem(30px) 0;

--- a/themes/startwords/assets/scss/main.scss
+++ b/themes/startwords/assets/scss/main.scss
@@ -16,6 +16,7 @@
 @import 'article/summary';
 @import 'article/single';
 @import 'article/notes';
+@import 'article/figure';
 
 // issues
 @import 'issue/global';

--- a/themes/startwords/layouts/shortcodes/figure.html
+++ b/themes/startwords/layouts/shortcodes/figure.html
@@ -24,7 +24,8 @@
     {{ with $small.RelPermalink }}{{ . }} 800w, {{ end }}
     {{ with $medium.RelPermalink }}{{ . }} 1200w, {{ end }}
     {{ with $large.RelPermalink }}{{ . }} 1500w, {{ end }}
-    {{ with $huge.RelPermalink }}{{ . }} 1800w{{ end }}'
+    {{ with $huge.RelPermalink }}{{ . }} 1800w, {{ end }}
+    {{ if gt $img.Width "1800" }}{{ $img.RelPermalink }} {{ $img.Width }}w{{ end }}'
     {{- if or (.Get "alt") (.Get "caption") }}
     alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
     {{- end -}}

--- a/themes/startwords/layouts/shortcodes/figure.html
+++ b/themes/startwords/layouts/shortcodes/figure.html
@@ -1,14 +1,46 @@
+{{/* get page resource matching filename specified as "src" in shortcode */}}
+{{ $img := .Page.Resources.GetMatch (printf "*%s*" (.Get "src")) }}
+
+{{/* set image derivative sizes */}}
+{{ $tinyw := default "500x" }}
+{{ $smallw := default "800x" }}
+{{ $mediumw := default "1200x" }}
+{{ $largew := default "1500x" }}
+
+{{/* resize the image to the given sizes */}}
+{{ .Scratch.Set "tiny" ($img.Resize $tinyw) }}
+{{ .Scratch.Set "small" ($img.Resize $smallw) }}
+{{ .Scratch.Set "medium" ($img.Resize $mediumw) }}
+{{ .Scratch.Set "large" ($img.Resize $largew) }}
+
+{{/* store processed images for output in srcset */}}
+{{ $tiny := .Scratch.Get "tiny" }}
+{{ $small := .Scratch.Get "small" }}
+{{ $medium := .Scratch.Get "medium" }}
+{{ $large := .Scratch.Get "large" }}
+
 <figure{{ with .Get "class" }} class="{{ . }}"{{ end }}{{ if .Get "extdesc_id" }} aria-describedby="{{ .Get "desc_id" }}"{{ end }}>
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
-    <img src="{{ .Get "src" }}" role="img"
+    <img src="{{ $img.RelPermalink }}" role="img"
+        srcset='
+        {{ if ge $img.Width "500" }}
+        {{ with $tiny.RelPermalink }}{{.}} 500w{{ end }}
+        {{ end }}
+        {{ if ge $img.Width "800" }}
+        {{ with $small.RelPermalink }}, {{.}} 800w{{ end }}
+        {{ end }}
+        {{ if ge $img.Width "1200" }}
+        {{ with $medium.RelPermalink }}, {{.}} 1200w{{ end }}
+        {{ end }}
+        {{ if ge $img.Width "1500" }}
+        {{ with $large.RelPermalink }}, {{.}} 1500w {{ end }}
+        {{ end }}'
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}
-         {{- with .Get "width" }} width="{{ . }}"{{ end -}}
-         {{- with .Get "height" }} height="{{ . }}"{{ end -}}
-    /> <!-- Closing img tag -->
+         class="{{ if ge $img.Width $img.Height }}landscape{{ else }}portrait{{ end }}">
     {{- if .Get "link" }}</a>{{ end -}}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
         <figcaption>
@@ -26,4 +58,3 @@
         </figcaption>
     {{- end }}
 </figure>
-

--- a/themes/startwords/layouts/shortcodes/figure.html
+++ b/themes/startwords/layouts/shortcodes/figure.html
@@ -2,59 +2,47 @@
 {{ $img := .Page.Resources.GetMatch (printf "*%s*" (.Get "src")) }}
 
 {{/* set image derivative sizes */}}
-{{ $tinyw := default "500x" }}
-{{ $smallw := default "800x" }}
-{{ $mediumw := default "1200x" }}
-{{ $largew := default "1500x" }}
+{{ $tiny_w := default "500x" }}
+{{ $small_w := default "800x" }}
+{{ $medium_w := default "1200x" }}
+{{ $large_w := default "1500x" }}
+{{ $huge_w := default "1800x" }}
 
-{{/* resize the image to the given sizes */}}
-{{ .Scratch.Set "tiny" ($img.Resize $tinyw) }}
-{{ .Scratch.Set "small" ($img.Resize $smallw) }}
-{{ .Scratch.Set "medium" ($img.Resize $mediumw) }}
-{{ .Scratch.Set "large" ($img.Resize $largew) }}
-
-{{/* store processed images for output in srcset */}}
-{{ $tiny := .Scratch.Get "tiny" }}
-{{ $small := .Scratch.Get "small" }}
-{{ $medium := .Scratch.Get "medium" }}
-{{ $large := .Scratch.Get "large" }}
+{{/* generate derviatives for output in srcset */}}
+{{ $tiny := ($img.Resize $tiny_w) }}
+{{ $small := ($img.Resize $small_w) }}
+{{ $medium := ($img.Resize $medium_w) }}
+{{ $large := ($img.Resize $large_w) }}
+{{ $huge := ($img.Resize $huge_w) }}
 
 <figure{{ with .Get "class" }} class="{{ . }}"{{ end }}{{ if .Get "extdesc_id" }} aria-describedby="{{ .Get "desc_id" }}"{{ end }}>
-    {{- if .Get "link" -}}
-        <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+{{- if .Get "link" -}}
+<a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
-    <img src="{{ $img.RelPermalink }}" role="img"
-        srcset='
-        {{ if ge $img.Width "500" }}
-        {{ with $tiny.RelPermalink }}{{.}} 500w{{ end }}
-        {{ end }}
-        {{ if ge $img.Width "800" }}
-        {{ with $small.RelPermalink }}, {{.}} 800w{{ end }}
-        {{ end }}
-        {{ if ge $img.Width "1200" }}
-        {{ with $medium.RelPermalink }}, {{.}} 1200w{{ end }}
-        {{ end }}
-        {{ if ge $img.Width "1500" }}
-        {{ with $large.RelPermalink }}, {{.}} 1500w {{ end }}
-        {{ end }}'
-         {{- if or (.Get "alt") (.Get "caption") }}
-         alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
-         {{- end -}}
-         class="{{ if ge $img.Width $img.Height }}landscape{{ else }}portrait{{ end }}">
+    <img src="{{ $large.RelPermalink }}" role="img" sizes="(max-width: 768px) 100%, 80%" loading="lazy"
+    srcset='{{ with $tiny.RelPermalink }}{{ . }} 500w, {{ end }}
+    {{ with $small.RelPermalink }}{{ . }} 800w, {{ end }}
+    {{ with $medium.RelPermalink }}{{ . }} 1200w, {{ end }}
+    {{ with $large.RelPermalink }}{{ . }} 1500w, {{ end }}
+    {{ with $huge.RelPermalink }}{{ . }} 1800w{{ end }}'
+    {{- if or (.Get "alt") (.Get "caption") }}
+    alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
+    {{- end -}}
+    class="{{ if ge $img.Width $img.Height }}landscape{{ else }}portrait{{ end }}">
     {{- if .Get "link" }}</a>{{ end -}}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
-        <figcaption>
-            {{ with (.Get "title") -}}
-                <h4>{{ . }}</h4>
+    <figcaption>
+        {{ with (.Get "title") -}}
+        <h4>{{ . }}</h4>
+        {{- end -}}
+        {{- if or (.Get "caption") (.Get "attr") -}}<p>
+        {{- .Get "caption" | markdownify -}}
+        {{- with .Get "attrlink" }}
+        <a href="{{ . }}">
             {{- end -}}
-            {{- if or (.Get "caption") (.Get "attr") -}}<p>
-                {{- .Get "caption" | markdownify -}}
-                {{- with .Get "attrlink" }}
-                    <a href="{{ . }}">
-                {{- end -}}
-                {{- .Get "attr" | markdownify -}}
-                {{- if .Get "attrlink" }}</a>{{ end }}</p>
+            {{- .Get "attr" | markdownify -}}
+            {{- if .Get "attrlink" }}</a>{{ end }}</p>
             {{- end }}
         </figcaption>
-    {{- end }}
+        {{- end }}
 </figure>


### PR DESCRIPTION
this PR updates the `figure` shortcode to use hugo's image processing capabilities to generate derivatives and allow the browser to select the most appropriate image size using `srcset`. it also adds styling for images inside of `<figure>` in articles on all screens. the general approach is adapted from [this article on processing responsive images with Hugo](https://laurakalbag.com/processing-responsive-images-with-hugo/).

the image sizes chosen are the same ones as the linked article, since the idea is to create derivatives that sit comfortably "between" our chosen breakpoints (where the majority of device widths actually are). for more on the thinking behind that approach, see [this article on choosing breakpoints](https://medium.com/free-code-camp/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862).