### PR TITLE
Add ISSN placeholder to site config; include in article metadata if set

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,8 @@ googleAnalytics = "UA-87887700-8"
   license_text = "Creative Commons Attribution Non-commerical Share Alike License"
   images = ["social.png"]
   description = "A research periodical irregularly published by the Center for Digital Humanities at Princeton."
+  # set ISSN if/when there is one for inclusion in article metadata
+  ISSN = ""
 
 [markup.goldmark.renderer]
   unsafe = true

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -20,7 +20,7 @@
 {{ if .Params.doi }}<meta name="citation_doi" content="{{ .Params.doi }}"/>{{ end }}
 <meta name="citation_abstract" content="{{ .Summary | plainify | htmlEscape }}" />
 <meta name="citation_journal_title" content="{{ .Site.Title }}"/>
-{{/* TODO: add when/if we get an ISSN:  <meta name="citation_issn" content=""> */}}
+{{ with .Site.Params.ISSN }}<meta name="citation_issn" content="{{ . }}">{{ end }}
 <meta name="citation_issue" content="{{ .Parent.Params.number }}"/>
 <meta name="citation_publisher" content="Center for Digital Humanities, Princeton University"/>
 <meta name="DC.rights" content="{{ .Site.Params.license }}" />


### PR DESCRIPTION
ref #121

This is a pretty trivial change (I see now that I should have done it this way from the start!), but I thought you both would want to be aware of it and thought you could use the PR as a chance to review and — if you want — confirm on your local instance that setting an ISSN in the config does the right thing.