### PR TITLE
Adjust image sizing in articles (#111)

### DIFF
--- a/themes/startwords/assets/scss/article/_figure.scss
+++ b/themes/startwords/assets/scss/article/_figure.scss
@@ -13,19 +13,10 @@ body.article figure {
     img {
         display: block;
         margin: 0 auto;
-
-        &.landscape {
-            width: 100%;
-            @media (min-width: $breakpoint-m) {
-                width: calc(100% + 200px);
-                margin-left: rem(-100px);
-                margin-right: rem(-100px);
-            }
-        }
+        width: 100%;
 
         &.portrait {
             width: 75%;
-            @media (min-width: $breakpoint-m) { width: 100%; }
         }
     }
 


### PR DESCRIPTION
- landscape mode images now match the width of paragraphs on all screens
- portrait mode images are 75% of the width of paragraphs on all screens
- svg images are now handled identically to landscape mode images