### PR TITLE
Adjust masthead formatting & content on the about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -13,19 +13,22 @@ Each issue features two articles that speak to a common theme, feature, or conce
 
 *Startwords* is built with the Hugo static site generator using a custom-made theme. In support of open access principles, we publish all articles under a Creative Commons license (CC BY 4.0) and the [website code](https://github.com/Princeton-CDH/startwords) under an Apache 2.0 license.
 
-## Masthead
+{{< wrap class="masthead" >}}
 
-**Editor** | Grant Wythoff
+## Masthead 
 
-**UX Designer** | Gissoo Doroudian
+**Editor** Grant Wythoff
 
-**Developer** | Rebecca Sutton Koeser
+**UX Designer** Gissoo Doroudian
 
-**Developer** | Nick Budak
+**Technical**
+- Nick Budak
+- Rebecca Sutton Koeser
 
-**Board of Advisors** |
+**Board of Advisors**
 
 - Rebecca Munson
 - Natalia Ermolaev
 - Zoe LeBlanc
 - Meredith Martin
+{{</ wrap >}}

--- a/content/about.md
+++ b/content/about.md
@@ -24,11 +24,12 @@ Each issue features two articles that speak to a common theme, feature, or conce
 **Technical**
 - Nick Budak
 - Rebecca Sutton Koeser
+- Grant Wythoff
 
 **Board of Advisors**
 
-- Rebecca Munson
 - Natalia Ermolaev
 - Zoe LeBlanc
 - Meredith Martin
+- Rebecca Munson
 {{</ wrap >}}

--- a/themes/startwords/assets/scss/page/_global.scss
+++ b/themes/startwords/assets/scss/page/_global.scss
@@ -3,3 +3,15 @@
 body.page {
     ul { list-style: none; }    // non-bulleted lists
 }
+
+
+/* custom styles for about page */
+.masthead {
+    strong {
+        display: inline-block;
+        line-height: 1rem;
+        padding-right: 0.5rem;
+        margin-right: 0.25rem;
+        border-right: 0.1rem solid $dark-grey;
+    }
+}

--- a/themes/startwords/layouts/shortcodes/wrap.html
+++ b/themes/startwords/layouts/shortcodes/wrap.html
@@ -1,3 +1,3 @@
 <div class="{{ .Get "class" }}" id="{{ .Get "id" }}">
-{{ .Inner  }}
+{{ .Inner | markdownify }}
 </div>


### PR DESCRIPTION
Made a few revisions to the masthead on the about page:
- wrap the masthead so styles can be keyed to this section only
- revise the wrap shortcode to interpret markdown in wrapped content
- remove the | in the page text and add a border in the css so it looks similar but is not read by screen readers
- remove 'developer' role and make a 'technical' list with names similar to the advisors list (I think this better encompasses the range of work we did, which was not solely development)

Questions:
- @thatbudakguy better place to put the styles, to organize it more specifically?
- @thatbudakguy are you ok with 'technical' instead of developer? 
- @gwijthoff should you be listed under technical? You've worked on the site too. I don't know if it's assumed that editors are involved in that kind of work, it seems like in a lot of cases they wouldn't be
- @gwijthoff What is the logic for the order of names on the board of advisors list? Should it be alphabetical?