### PR TITLE
revert baseURL to full form

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,4 @@
-#baseURL = "https://startwords.cdh.princeton.edu/"
-baseURL = "/"
+baseURL = "https://startwords.cdh.princeton.edu/"
 title = "Startwords"
 theme = "startwords"
 copyright = "This work is licensed under a Creative Commons Attribution 4.0 International License."


### PR DESCRIPTION
testing something out:

- revert the hugo config to use our full startwords.cdh.princeton.edu URL as the `baseURL`
- tell render to set an environment variable (`HUGO_BASEURL`) that overrides this for builds and sets it to `/`