### PR TITLE
Fix clipped spacing at article top (#154)

### DIFF
--- a/content/issues/1/data-beyond-vision/style.css
+++ b/content/issues/1/data-beyond-vision/style.css
@@ -5,7 +5,6 @@ article { position: relative; }
 article::before {
     content: "";
     position: absolute;
-    top: 200px;
     width: 100%;
     height: 100%;
     opacity: 0.3;


### PR DESCRIPTION
This had a weird solution that I don't totally understand, but it does appear to work! Removing the spacing that pushed down the background scarf allowed the page to scroll up to the top. So, the issue was localized to the DBV essay only.

@gwijthoff check the render preview when it's finished and let me know if the problem is resolved for you too.