### PR TITLE
Add a few more regexes to clean up text output

### DIFF
--- a/content/issues/2/creating-and-recreating-virtual-community/index.md
+++ b/content/issues/2/creating-and-recreating-virtual-community/index.md
@@ -1,8 +1,7 @@
 ---
 type: article
 slug: 'creating-and-recreating-virtual-community'
-title: |
-  Creating and Recreating Virtual Community on Douglass Day
+title: Creating and Recreating Virtual Community on Douglass Day
 order: 3
 authors:
     - Justin Smith

--- a/content/issues/2/serendipity-in-the-cairo-geniza/index.md
+++ b/content/issues/2/serendipity-in-the-cairo-geniza/index.md
@@ -1,8 +1,7 @@
 ---
 type: article
 slug: 'serendipity-in-the-cairo-geniza'
-title: |
-  Serendipity in the Cairo Geniza
+title: Serendipity in the Cairo Geniza
 order: 4
 authors:
     - Matthew Dudley

--- a/themes/startwords/data/article_txt_replace.toml
+++ b/themes/startwords/data/article_txt_replace.toml
@@ -16,7 +16,7 @@ replacement = ""
 comment = "remove script embed (multiline, . match includes newline)"
 
 [[args]]
-pattern = '(?ms)\{\{\< wrap class=\"tweet-group print-only-preview\" \>\}\}.*\{\{\< \/wrap \>\}\}'
+pattern = '(?ms)\{\{\< wrap class=\"tweet-group print-only-preview\" \>\}\}[^{]*\{\{\< \/wrap \>\}\}'
 replacement = ""
 comment = "remove tweet group print preview"
 

--- a/themes/startwords/data/article_txt_replace.toml
+++ b/themes/startwords/data/article_txt_replace.toml
@@ -73,10 +73,10 @@ comment = "remove anchor links within the current document"
 
 [[args]]
 pattern = '(?ms)^\s*$(^\s*$)+'
-replacement = "\n"
+replacement = ""
 comment = "Consolidate multiple newlines"
 
 [[args]]
 pattern = '^'
-replacement = "\n\n"
+replacement = "\n"
 comment = "Add newline to beginning of text"

--- a/themes/startwords/data/article_txt_replace.toml
+++ b/themes/startwords/data/article_txt_replace.toml
@@ -11,6 +11,16 @@ comment = "Testing a simple string replacement."
 skip = true
 
 [[args]]
+pattern = '(?ms)<script.*</script>'
+replacement = ""
+comment = "remove script embed (multiline, . match includes newline)"
+
+[[args]]
+pattern = '(?ms)\{\{\< wrap class=\"tweet-group print-only-preview\" \>\}\}.*\{\{\< \/wrap \>\}\}'
+replacement = ""
+comment = "remove tweet group print preview"
+
+[[args]]
 pattern = '!\[([^\]]+)\]\([^\)]+\)'
 replacement = "[IMAGE: $1]"
 comment = "convert markdown image"
@@ -60,3 +70,13 @@ comment = "remove custom anchor names (markdown syntax)"
 pattern = '\[(.+)\]\(#.*\)'
 replacement = "$1"
 comment = "remove anchor links within the current document"
+
+[[args]]
+pattern = '(?ms)^\s*$(^\s*$)+'
+replacement = "\n"
+comment = "Consolidate multiple newlines"
+
+[[args]]
+pattern = '^'
+replacement = "\n\n"
+comment = "Add newline to beginning of text"

--- a/themes/startwords/layouts/article/single.txt
+++ b/themes/startwords/layouts/article/single.txt
@@ -19,8 +19,8 @@
 |{{ if .Params.doi }}
 |  doi:{{ .Params.doi }}{{ end }}
 |{{ if .Params.tags }}
-|  {{ range .Params.tags }}#{{ . }}{{ end }}{{ end }}
-|
+|  {{ range .Params.tags }}#{{ . }}
+|{{ end }}{{ end }}
 ⩩-----------------------------------------------------------------------------------⟩
 |
 |  Issue {{ .Parent.Params.number }}: {{ upper .Parent.Params.theme }}


### PR DESCRIPTION
adds new regexes to improve text output for issue 2
- strip out multiline script embeds in article (test case: kaltura video for serendipity essay)
- strip out twitter group print preview block (test case: community essay)
- consolidate multiple newlines (some essays had many blocks of empty lines previously)
- add newline to the beginning of the essay (per @gwijthoff request; adding in the template didn't do anything!)