### PR TITLE
20 build author taxonomy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,9 +11,9 @@ enableGitInfo = true
 timeout = "300s"
 
 # disable taxonomies until we are ready to use them and have templates
-disableKinds = ["taxonomy", "term", "tag"]
-#[taxonomies]
-#  author = "authors"
+disableKinds = ["term", "tag"] # "taxonomy"
+[taxonomies]
+  author = "authors"
 #  tag = "tags"
 
 [permalinks]

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ enableGitInfo = true
 timeout = "300s"
 
 # disable taxonomies until we are ready to use them and have templates
-disableKinds = ["term", "tag"] # "taxonomy"
+# disableKinds = ["term", "tag", "taxonomy"]
 [taxonomies]
   author = "authors"
 #  tag = "tags"

--- a/config.toml
+++ b/config.toml
@@ -11,9 +11,9 @@ enableGitInfo = true
 timeout = "300s"
 
 # disable taxonomies until we are ready to use them and have templates
-# disableKinds = ["term", "tag", "taxonomy"]
-[taxonomies]
-  author = "authors"
+disableKinds = ["term", "tag", "taxonomy"]
+# [taxonomies]
+#  author = "authors"
 #  tag = "tags"
 
 [permalinks]

--- a/content/authors/becky-rother/_index.md
+++ b/content/authors/becky-rother/_index.md
@@ -1,5 +1,0 @@
----
-title: Becky Rother
-orcid: ORCID
-affiliation: AFFILIATION
----

--- a/content/authors/becky-rother/_index.md
+++ b/content/authors/becky-rother/_index.md
@@ -1,0 +1,5 @@
+---
+title: Becky Rother
+orcid: ORCID
+affiliation: AFFILIATION
+---

--- a/themes/startwords/archetypes/author/_index.md
+++ b/themes/startwords/archetypes/author/_index.md
@@ -1,0 +1,5 @@
+---
+title: {{ replace .Name "-" " " | title }}
+orcid: ORCID
+affiliation: AFFILIATION
+---

--- a/themes/startwords/archetypes/author/_index.md
+++ b/themes/startwords/archetypes/author/_index.md
@@ -1,5 +1,0 @@
----
-title: {{ replace .Name "-" " " | title }}
-orcid: ORCID
-affiliation: AFFILIATION
----

--- a/themes/startwords/data/authors.yaml
+++ b/themes/startwords/data/authors.yaml
@@ -10,20 +10,20 @@
 - name: Matthew Dudley
   affiliation: Yale University
 - name: Samantha Blickhan
-  affiliation: Affiliation
-  orcid: ORCID
+  # affiliation: Affiliation
+  # orcid: ORCID
 - name: Shaun A. Noordin
-  affiliation: Affiliation
-  orcid: ORCID
+  # affiliation: Affiliation
+  # orcid: ORCID
 - name: Steffy Reader
-  affiliation: Affiliation
-  orcid: ORCID
+  # affiliation: Affiliation
+  # orcid: ORCID
 - name: Victoria Anne Van Hyning
-  affiliation: Affiliation
-  orcid: ORCID
+  # affiliation: Affiliation
+  # orcid: ORCID
 - name: Will Granger
-  affiliation: Affiliation
-  orcid: ORCID
+  # affiliation: Affiliation
+  # orcid: ORCID
 - name: Gissoo Doroudian
   affiliation: Princeton University
   orcid: 0000-0002-6702-6964

--- a/themes/startwords/data/authors.yaml
+++ b/themes/startwords/data/authors.yaml
@@ -1,0 +1,5 @@
+- name: Becky Rother
+  affiliation: Affiliation
+- name: Kevin McElwee
+  orcid: 0000-0003-2577-8102
+  affiliation: Princeton University

--- a/themes/startwords/data/authors.yaml
+++ b/themes/startwords/data/authors.yaml
@@ -1,5 +1,41 @@
 - name: Becky Rother
+- name: Courtney Murray
+  affiliation: Pennsylvania State University
+- name: Jim Casey
+  affiliation: Pennsylvania State University
+- name: Justin Smith
+  affiliation: Pennsylvania State University
+- name: Mason A. Jones
+  affiliation: University of Maryland
+- name: Matthew Dudley
+  affiliation: Yale University
+- name: Samantha Blickhan
   affiliation: Affiliation
-- name: Kevin McElwee
-  orcid: 0000-0003-2577-8102
+  orcid: ORCID
+- name: Shaun A. Noordin
+  affiliation: Affiliation
+  orcid: ORCID
+- name: Steffy Reader
+  affiliation: Affiliation
+  orcid: ORCID
+- name: Victoria Anne Van Hyning
+  affiliation: Affiliation
+  orcid: ORCID
+- name: Will Granger
+  affiliation: Affiliation
+  orcid: ORCID
+- name: Gissoo Doroudian
   affiliation: Princeton University
+  orcid: 0000-0002-6702-6964
+- name: Nick Budak
+  affiliation: Princeton University
+  orcid: 0000-0002-4542-0899
+- name: Rebecca Munson
+  affiliation: Princeton University
+  orcid: 0000-0002-8735-8405
+- name: Rebecca Sutton Koeser
+  affiliation: Princeton University
+  orcid: 0000-0002-8762-8057
+- name: Xinyi Li
+  affiliation: Princeton University
+  orcid: 0000-0002-6114-3182

--- a/themes/startwords/layouts/authors/list.html
+++ b/themes/startwords/layouts/authors/list.html
@@ -1,5 +1,5 @@
 <ul>
-    {{ range $.Site.Data.authors }}
+    {{ range sort $.Site.Data.authors "name" }}
     <li>
         {{ if isset . "orcid"}}
         <a href="https://orcid.org/{{ .orcid }}">{{ .name }}</a>

--- a/themes/startwords/layouts/authors/list.html
+++ b/themes/startwords/layouts/authors/list.html
@@ -1,0 +1,7 @@
+<ul>
+    {{ range .Pages }}
+        <li>
+            <a href="{{ .Permalink }}">{{ .Title }}</a>
+        </li>
+    {{ end }}
+</ul>

--- a/themes/startwords/layouts/authors/list.html
+++ b/themes/startwords/layouts/authors/list.html
@@ -1,7 +1,14 @@
 <ul>
-    {{ range .Pages }}
-        <li>
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-        </li>
+    {{ range $.Site.Data.authors }}
+    <li>
+        {{ if isset . "orcid"}}
+        <a href="https://orcid.org/{{ .orcid }}">{{ .name }}</a>
+        {{ else }}
+        {{ .name }}
+        {{ end }}
+        {{ if isset . "affiliation"}}
+        ({{ .affiliation }})
+        {{ end }}
+    </li>
     {{ end }}
 </ul>

--- a/themes/startwords/layouts/authors/list.html
+++ b/themes/startwords/layouts/authors/list.html
@@ -1,12 +1,13 @@
 <ul>
-    {{ range sort $.Site.Data.authors "name" }}
+    {{ range sort $.Site.Data.authors }}
     <li>
-        {{ if isset . "orcid"}}
+
+        {{ if .orcid}}
         <a href="https://orcid.org/{{ .orcid }}">{{ .name }}</a>
         {{ else }}
         {{ .name }}
         {{ end }}
-        {{ if isset . "affiliation"}}
+        {{ if .affiliation}}
         ({{ .affiliation }})
         {{ end }}
     </li>

--- a/themes/startwords/layouts/authors/list.html
+++ b/themes/startwords/layouts/authors/list.html
@@ -1,7 +1,6 @@
 <ul>
     {{ range sort $.Site.Data.authors }}
-    <li>
-
+    <li id="{{ urlize .name }}">
         {{ if .orcid}}
         <a href="https://orcid.org/{{ .orcid }}">{{ .name }}</a>
         {{ else }}

--- a/themes/startwords/layouts/partials/authors.html
+++ b/themes/startwords/layouts/partials/authors.html
@@ -1,5 +1,7 @@
 <ul class="authors">
     {{ range .Params.Authors }}
-    <li><address>{{ . }}</address></li>
+    <li>
+        <address><a href="/authors/{{ urlize . }}">{{ . }}</a></address>
+    </li>
     {{ end }}
 </ul>

--- a/themes/startwords/layouts/partials/authors.html
+++ b/themes/startwords/layouts/partials/authors.html
@@ -1,7 +1,7 @@
 <ul class="authors">
     {{ range .Params.Authors }}
     <li>
-        <address><a href="/authors/{{ urlize . }}">{{ . }}</a></address>
+        <address><a href="/authors#{{ urlize . }}">{{ . }}</a></address>
     </li>
     {{ end }}
 </ul>


### PR DESCRIPTION
### Data template approach

I don't think it'd be too hard to add names to the yaml, we'll want to add ORCID and affiliation info anyway. 

* I assume we also want the article information as well? Do we want detail pages or we could use a `<summary>` dropdown tag? Do we want author detail pages?

- [ ] Add "sort_name" field to better sort authors

### Taxonomy approach

- [ ] Add logic to `list.html` to display ORCID and affiliation information
- [ ] Add documentation for archetype after other #217 is merged and rebasing

* Styling?
* Can information from author pages be collapsed into the list view?
* Hugo doesn't strip periods for slugs. Do we want to overwrite them?

To add metadata, we need to create folders for everyone (!) shell command to make this faster if/when we get there:
```sh
hugo new --kind author /authors/becky-rother
hugo new --kind author /authors/courtney-murray
hugo new --kind author /authors/jim-casey
hugo new --kind author /authors/justin-smith
hugo new --kind author /authors/mason-a.-jones
hugo new --kind author /authors/matthew-dudley
hugo new --kind author /authors/samantha-blickhan
hugo new --kind author /authors/shaun-a.-noordin
hugo new --kind author /authors/steffy-reader
hugo new --kind author /authors/victoria-anne-van-hyning
hugo new --kind author /authors/will-granger
hugo new --kind author /authors/gissoo-doroudian
hugo new --kind author /authors/nick-budak
hugo new --kind author /authors/rebecca-munson
hugo new --kind author /authors/rebecca-sutton-koeser
hugo new --kind author /authors/xinyi-li
```