### PR TITLE
article & issue translation toggle and metadata

### DIFF
--- a/themes/startwords/i18n/en.yaml
+++ b/themes/startwords/i18n/en.yaml
@@ -21,6 +21,13 @@ read-more:
   other: "Read more..."
 footer-links:
   other: footer links
+# translation links
+English:
+  other: English
+Spanish:
+  other: Spanish
+read-in-lang:
+  other: read this page in {{ . }}
 # error page
 error:
   other: Error

--- a/themes/startwords/i18n/es.yaml
+++ b/themes/startwords/i18n/es.yaml
@@ -21,6 +21,13 @@ read-more:
   other: "Read more..."
 footer-links:
   other: footer links
+# translation links
+English:
+  other: Inglés
+Spanish:
+  other:  Español
+read-in-lang:
+  other: read this page in {{ . }}
 # error page
 error:
   other: Error

--- a/themes/startwords/layouts/partials/translations.html
+++ b/themes/startwords/layouts/partials/translations.html
@@ -3,7 +3,9 @@
     <h2 class="sr-only">{{ i18n "translations" }}</h2>
     <ul>
         {{- range $.AllTranslations -}}
-        <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .RelPermalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
+        {{ $translatedLangName := i18n .Language.LanguageName }}
+        {{ $label := i18n "read-in-lang" $translatedLangName }}
+        <li {{ if eq $.Lang .Lang }}class="current"{{ end }} >{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .RelPermalink }}" aria-label="{{ $label }}" title="{{ $label }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
         {{- end -}}
     </ul>
 </aside>


### PR DESCRIPTION
add translation toggle button and metadata for translated articles and translated issues

test with [translated article](https://startwords-dev-pr-242.onrender.com/issues/3/on-spanish-parrots/) on the render site for this pr

testing checklist:
- [x] translated article should have toggle buttons to switch back and forth between English and Spanish versions
- [x] toggle should indicate which language you are currently viewing
- [x] translated article metadata should include alternate links to all translations of the same article
- [x] articles without translations should not display the toggle
- [x] translated issue should have toggle buttons that behave similarly
- [x] untranslated issues should not have toggles

design review:
- [ ] please see what you think of the styles of the toggles; I implemented with CSS 3D effects but I'm not sure it's good enough
- [x] did I understand correctly which mode indicates the current language?