### PR TITLE
article language indicator

### DIFF
--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -123,10 +123,11 @@ aside.translations {
 
 /* language indicators for articles on issue detail page and home page*/
 #features .languages {
-    margin-bottom: rem(12px);
+    margin-bottom: rem(18px);
 
     span {
         @include dark-bg-language-chip;
+        margin-right: rem(4px);
     }
 }
 

--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -1,7 +1,8 @@
 /* translation/localization styles */
 
 /* translation toggle */
-article header, .issue-summary .container {
+article header,
+.issue-summary .container {
     /* make space for translations toggle */
     position: relative;
     padding-top: 45px;
@@ -94,21 +95,41 @@ aside.translations {
 }
 
 .issue-list {
-    .translations {
+    .languages {
         padding: 2rem 0 1.5rem 2rem;
-
-        span {
-            display: inline-block;
-            margin-right: 0.5rem;
-            width: 1.7rem;
-            height: 1.3rem;
-            background: white;
-            /* Purple */
-            border: 2px solid $purple;
-            border-radius: 4px;
-            text-transform: uppercase;
-            text-align: center;
-            color: $black;
-        }
     }
+}
+
+.languages {
+    span {
+        display: inline-block;
+        margin-right: 0.5rem;
+        width: 1.7rem;
+        height: 1.3rem;
+        background: white;
+        border: 2px solid $purple;
+        border-radius: 4px;
+        text-transform: uppercase;
+        text-align: center;
+        color: $black;
+    }
+}
+
+@mixin dark-bg-language-chip {
+    background: $darkest-purple;
+    color: $light-purple;
+    border: 2px solid $darkest-purple;
+}
+
+/* language indicators for articles on issue detail page and home page*/
+#features .languages {
+    margin-bottom: rem(12px);
+
+    span {
+        @include dark-bg-language-chip;
+    }
+}
+
+.snippets .languages {
+    margin-top: rem(5px);
 }

--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -1,93 +1,97 @@
+/* translation/localization styles */
+
 /* translation toggle */
-article header {
+article header, .issue-summary .container {
+    /* make space for translations toggle */
     position: relative;
     padding-top: 45px;
+}
 
-    .translations {
-        position: absolute;
-        right: 0;
-        top: 0;
-        padding: 0;
+aside.translations {
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: 0;
+    margin: 0;
+
+    ul {
         margin: 0;
+        padding: 0;
+        perspective: 1477px;
+        perspective-origin: 150% 375%;
+    }
 
-        ul {
-            perspective: 1477px;
-            perspective-origin: 150% 375%;
+    li {
+        list-style-type: none;
+        display: inline-block;
+        position: relative;
+        background-color: $light-purple;
+        color: $dark-purple;
+        font-family: $font-sans;
+        font-size: 1.1rem;
+        transform-style: preserve-3d;
+
+        --button-width: 40px;
+        --button-height: 34px;
+
+        width: var(--button-width);
+        height: var(--button-height);
+        // unselected
+        transform: scale3d(1, 1, 1.75) translate3d(5px, 3px, var(--button-width));
+
+        @media (min-width: $breakpoint-s) {
+            --button-width: 45px;
+            --button-height: 40px;
+            font-size: 1.2rem;
+        }
+        &.current {
+            background-color: $medium-dark-purple;
+            font-weight: 600;
+            transform: none;
         }
 
-        li {
-            list-style-type: none;
+        a,
+        span {
+            width: 100%;
+            text-align: center;
+            line-height: var(--button-height);
+            text-decoration: none;
+            display: block;
+        }
+
+        &:not(:first-child):not(.current) {
+            /* remove space between */
+            // transform is slightly different for button on right
+            transform: scale3d(1, 1, 1.75)
+                translate3d(calc(var(--button-width) * 0.1), calc(var(--button-width) * 0.08), var(--button-width));
+        }
+
+        /* use pseduo-elements to create visible cube faces */
+        &::before,
+        &::after {
+            content: " ";
+            box-sizing: border-box;
             display: inline-block;
-            position: relative;
-            background-color: $light-purple;
-            color: $dark-purple;
-            font-family: $font-sans;
-            font-size: 1.1rem;
-            transform-style: preserve-3d;
-
-            --button-width: 40px;
-            --button-height: 34px;
-
-            width: var(--button-width);
-            height: var(--button-height);
-            // unselected
-            transform: scale3d(1, 1, 1.75) translate3d(5px, 3px, var(--button-width));
-
-            @media (min-width: $breakpoint-s) {
-                --button-width: 45px;
-                --button-height: 40px;
-                font-size: 1.2rem;
-            }
-            &.current {
-                background-color: $medium-dark-purple;
-                font-weight: 600;
-                transform: none;
-            }
-
-            a,
-            span {
-                width: 100%;
-                text-align: center;
-                line-height: var(--button-height);
-                text-decoration: none;
-                display: block;
-            }
-
-            &:not(:first-child):not(.current) {
-                /* remove space between */
-                // transform is slightly different for button on right
-                transform: scale3d(1, 1, 1.75) translate3d(calc(var(--button-width) * 0.1), calc(var(--button-width) * 0.08), var(--button-width));
-            }
-
-            /* use pseduo-elements to create visible cube faces */
-            &::before,
-            &::after {
-                content: " ";
-                box-sizing: border-box;
-                display: inline-block;
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background-color: $medium-purple;
-                border: 1px solid $medium-purple;
-            }
-            &::before {
-                /* cube face right */
-                transform: rotateY(-270deg) translateX(var(--button-width));
-                transform-origin: top right;
-            }
-            &::after {
-                /* cube face bottom */
-                transform: rotateX(270deg) translateY(var(--button-height));
-                transform-origin: bottom center;
-            }
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: $medium-purple;
+            border: 1px solid $medium-purple;
+        }
+        &::before {
+            /* cube face right */
+            transform: rotateY(-270deg) translateX(var(--button-width));
+            transform-origin: top right;
+        }
+        &::after {
+            /* cube face bottom */
+            transform: rotateX(270deg) translateY(var(--button-height));
+            transform-origin: bottom center;
         }
     }
 }
-/* translation/localization styles */
-
 
 .issue-list {
     .translations {
@@ -108,4 +112,3 @@ article header {
         }
     }
 }
-

--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -22,13 +22,22 @@ article header {
             background-color: $light-purple;
             color: $dark-purple;
             font-family: $font-sans;
-            font-size: 1.2rem;
+            font-size: 1.1rem;
             transform-style: preserve-3d;
-            width: 45px;
-            height: 40px;
-            // unselected
-            transform: scale3d(1, 1, 1.75) translate3d(5px, 3px, 45px);
 
+            --button-width: 40px;
+            --button-height: 34px;
+
+            width: var(--button-width);
+            height: var(--button-height);
+            // unselected
+            transform: scale3d(1, 1, 1.75) translate3d(5px, 3px, var(--button-width));
+
+            @media (min-width: $breakpoint-s) {
+                --button-width: 45px;
+                --button-height: 40px;
+                font-size: 1.2rem;
+            }
             &.current {
                 background-color: $medium-dark-purple;
                 font-weight: 600;
@@ -39,7 +48,7 @@ article header {
             span {
                 width: 100%;
                 text-align: center;
-                line-height: 40px;
+                line-height: var(--button-height);
                 text-decoration: none;
                 display: block;
             }
@@ -47,7 +56,7 @@ article header {
             &:not(:first-child):not(.current) {
                 /* remove space between */
                 // transform is slightly different for button on right
-                transform: scale3d(1, 1, 1.75) translate3d(8px, 4px, 45px);
+                transform: scale3d(1, 1, 1.75) translate3d(calc(var(--button-width) * 0.1), calc(var(--button-width) * 0.08), var(--button-width));
             }
 
             /* use pseduo-elements to create visible cube faces */
@@ -66,12 +75,12 @@ article header {
             }
             &::before {
                 /* cube face right */
-                transform: rotateY(-270deg) translateX(45px);
+                transform: rotateY(-270deg) translateX(var(--button-width));
                 transform-origin: top right;
             }
             &::after {
                 /* cube face bottom */
-                transform: rotateX(270deg) translateY(40px);
+                transform: rotateX(270deg) translateY(var(--button-height));
                 transform-origin: bottom center;
             }
         }

--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -1,0 +1,79 @@
+/* translation toggle */
+article header {
+    position: relative;
+    padding-top: 45px;
+
+    .translations {
+        position: absolute;
+        right: 0;
+        top: 0;
+        padding: 0;
+        margin: 0;
+
+        ul {
+            perspective: 1477px;
+            perspective-origin: 150% 375%;
+        }
+
+        li {
+            list-style-type: none;
+            display: inline-block;
+            position: relative;
+            background-color: $light-purple;
+            color: $dark-purple;
+            font-family: $font-sans;
+            font-size: 1.2rem;
+            transform-style: preserve-3d;
+            width: 45px;
+            height: 40px;
+            // unselected
+            transform: scale3d(1, 1, 1.75) translate3d(5px, 3px, 45px);
+
+            &.current {
+                background-color: $medium-dark-purple;
+                font-weight: 600;
+                transform: none;
+            }
+
+            a,
+            span {
+                width: 100%;
+                text-align: center;
+                line-height: 40px;
+                text-decoration: none;
+                display: block;
+            }
+
+            &:not(:first-child):not(.current) {
+                /* remove space between */
+                // transform is slightly different for button on right
+                transform: scale3d(1, 1, 1.75) translate3d(8px, 4px, 45px);
+            }
+
+            /* use pseduo-elements to create visible cube faces */
+            &::before,
+            &::after {
+                content: " ";
+                box-sizing: border-box;
+                display: inline-block;
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background-color: $medium-purple;
+                border: 1px solid $medium-purple;
+            }
+            &::before {
+                /* cube face right */
+                transform: rotateY(-270deg) translateX(45px);
+                transform-origin: top right;
+            }
+            &::after {
+                /* cube face bottom */
+                transform: rotateX(270deg) translateY(40px);
+                transform-origin: bottom center;
+            }
+        }
+    }
+}

--- a/themes/startwords/assets/scss/_variables.scss
+++ b/themes/startwords/assets/scss/_variables.scss
@@ -8,6 +8,7 @@ $medium-purple: #C7A6FF;
 $medium-dark-purple: #AE80FF;
 $purple:       #4C2A85;
 $dark-purple:  #3D206C;
+$darkest-purple: #38235B;
 $dark-grey:    #404040;
 $grey:         #808080;
 $black:        #000000;

--- a/themes/startwords/assets/scss/_variables.scss
+++ b/themes/startwords/assets/scss/_variables.scss
@@ -4,6 +4,8 @@
 $off-white:    #F6F6F6;
 $light-grey:   #E9E9E9;
 $light-purple: #E0CEFF;
+$medium-purple: #C7A6FF;
+$medium-dark-purple: #AE80FF;
 $purple:       #4C2A85;
 $dark-purple:  #3D206C;
 $dark-grey:    #404040;

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -16,7 +16,9 @@ $preview-height-xl: rem(250px);  // 1024px-
 
     @media (min-width: $breakpoint-m) { font-size: rem(18px); }
 
-    a:not(.doi) { text-decoration: none; }
+    a:not(.doi) {
+        text-decoration: none;
+    }
 
     p {
         margin: 0;
@@ -52,7 +54,7 @@ $preview-height-xl: rem(250px);  // 1024px-
         font-weight: bold;
         font-style: italic;
         text-decoration: underline;
-        margin: rem(12px) 0;
+        margin: rem(12px) 0 rem(16px);
 
         &::after {
             position: relative;
@@ -131,7 +133,7 @@ $preview-height-xl: rem(250px);  // 1024px-
         }
     }
 
-    &:not(:first-of-type):not(:nth-of-type(2)) {  
+    &:not(:first-of-type):not(:nth-of-type(2)) {
         padding-top: inherit;
     }
 
@@ -141,7 +143,7 @@ $preview-height-xl: rem(250px);  // 1024px-
     &:nth-of-type(2):nth-last-of-type(2) { padding-top: 30%; }
     // Apply when there are five features
     &:nth-of-type(2):nth-last-of-type(4) { padding-top: 30%; }
-    
+
 
     // inverted portions use light purple instead of white
     &.inverted,

--- a/themes/startwords/assets/scss/main.scss
+++ b/themes/startwords/assets/scss/main.scss
@@ -12,6 +12,7 @@
 @import 'home';
 @import 'error';
 @import 'darkmode';
+@import 'i18n';
 
 // articles
 @import 'article/global';

--- a/themes/startwords/i18n/en.yaml
+++ b/themes/startwords/i18n/en.yaml
@@ -21,6 +21,15 @@ read-more:
   other: "Read more..."
 footer-links:
   other: footer links
+# translation links
+languages available:
+  other: languages available
+available-in-lang:
+  other: Available in {{ . }}
+English:
+  other: English
+Spanish:
+  other: Spanish
 # error page
 error:
   other: Error

--- a/themes/startwords/i18n/es.yaml
+++ b/themes/startwords/i18n/es.yaml
@@ -21,6 +21,15 @@ read-more:
   other: "Read more..."
 footer-links:
   other: footer links
+# translation links
+languages available:
+  other: languages available
+available-in-lang:
+  other: disponible en {{ . }}
+English:
+  other: Inglés
+Spanish:
+  other: Español
 # error page
 error:
   other: Error

--- a/themes/startwords/layouts/_default/baseof.html
+++ b/themes/startwords/layouts/_default/baseof.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#3D206C" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    {{/* when a page is available in translation, link all versions as alternates */}}
+    {{- if .IsTranslated -}} {{/* include current language */}}
+        <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- range .Translations -}}
+        <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- end -}}
+    {{- end -}}
     {{ $favicon_path := "/img/favicon" | relURL}}
     <link rel="apple-touch-icon" sizes="180x180" href="{{ $favicon_path }}/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="{{ $favicon_path }}/favicon-32x32.png" />

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -64,17 +64,7 @@
                 {{- end }}
                 </p>
 
-            {{ if .IsTranslated }}
-            <aside class="translations">
-                <h2 class="sr-only">{{ i18n "translations" }}</h2>
-                <ul>
-                    {{- range $.AllTranslations -}}
-                    <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .RelPermalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
-                    {{- end -}}
-                </ul>
-            </aside>
-            {{ end }}
-
+                {{ partial "translations.html" . }}
             </header>
 
             {{/* elements for PDF header & footer */}}

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -63,6 +63,18 @@
                     <a href="{{ . }}" rel="alternate" type="application/pdf">PDF</a>
                 {{- end }}
                 </p>
+
+            {{ if .IsTranslated }}
+            <aside class="translations">
+                <h2 class="sr-only">{{ i18n "translations" }}</h2>
+                <ul>
+                    {{- range $.AllTranslations -}}
+                    <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .Permalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
+                    {{- end -}}
+                </ul>
+            </aside>
+            {{ end }}
+
             </header>
 
             {{/* elements for PDF header & footer */}}

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -69,7 +69,7 @@
                 <h2 class="sr-only">{{ i18n "translations" }}</h2>
                 <ul>
                     {{- range $.AllTranslations -}}
-                    <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .Permalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
+                    <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .RelPermalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
                     {{- end -}}
                 </ul>
             </aside>

--- a/themes/startwords/layouts/article/summary.html
+++ b/themes/startwords/layouts/article/summary.html
@@ -2,6 +2,7 @@
     <div class="bg-text" role="presentation">{{ .Summary | plainify }}</div>
     <p>{{ .Summary | plainify }}</p>
     <h2><a class="highlight-focus" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+    {{ partial "available_languages.html" . }}
     {{ partial "authors" . }}
     {{ with .Params.doi }}
     <a class="doi highlight-focus" href="https://doi.org/{{ . }}">{{ . }}</a>

--- a/themes/startwords/layouts/issue/list.html
+++ b/themes/startwords/layouts/issue/list.html
@@ -18,11 +18,7 @@
                     <a class="highlight-focus" href="{{ .RelPermalink }}" aria-label="{{ i18n "issue" }} {{ .Params.number }}">
                         {{ .Render "summary" }}
                     </a>
-                    <div class="translations" aria-label='{{ "languages available:" }}'> {{/* todo: translate */}}
-                        {{- range .AllTranslations -}}
-                            <span aria-label="{{ .Language.LanguageName }}" title="Available in {{ .Language.LanguageName }}">{{ .Lang | upper }}</span>
-                        {{ end }}
-                    </div>
+                   {{ partial "available_languages.html" . }}
                 </li>
                 {{ end }}
                 {{ end }}

--- a/themes/startwords/layouts/issue/single.html
+++ b/themes/startwords/layouts/issue/single.html
@@ -10,13 +10,15 @@
 <main>
     <div class="issue-summary grid">
         <div class="container">
-            <span class="number">Issue {{ .Params.number }}</span>
+            <span class="number">{{ i18n "issue" }} {{ .Params.number }}</span>
             <h1 class="theme">{{ .Params.theme }}</h1>
             <div class="summary">{{ .Content }}</div>
             <a href="#features" class="chevron highlight-focus">
                 <img src="/img/chevron.svg" alt="skip to featured content"/>
             </a>
+            {{ partial "translations.html" . }}
         </div>
+
     </div>
     {{ partial "issue/features.html" . }}
     <section class="grid masthead">

--- a/themes/startwords/layouts/partials/available_languages.html
+++ b/themes/startwords/layouts/partials/available_languages.html
@@ -1,0 +1,7 @@
+{{/* display language "chips" to make available language explicit */}}
+<div class="languages" aria-label='{{ i18n "languages available" }}'>
+    {{- range .AllTranslations -}}
+    {{ $translatedLangName := i18n .Language.LanguageName }}
+        <span aria-label="{{ .Language.LanguageName }}" title="{{ i18n "available-in-lang" $translatedLangName }}">{{ .Lang | upper }}</span>
+    {{ end }}
+</div>

--- a/themes/startwords/layouts/partials/issue/features.html
+++ b/themes/startwords/layouts/partials/issue/features.html
@@ -15,6 +15,7 @@
                 <a class="highlight-focus" href="{{ .RelPermalink }}">{{ .Title }}</a>
                 {{ partial "authors" . }}
                 {{ partial "tags" . }}
+                {{ partial "available_languages.html" . }}
             </div>
             {{ end }}
         </div>

--- a/themes/startwords/layouts/partials/translations.html
+++ b/themes/startwords/layouts/partials/translations.html
@@ -1,0 +1,10 @@
+{{ if .IsTranslated }}
+<aside class="translations">
+    <h2 class="sr-only">{{ i18n "translations" }}</h2>
+    <ul>
+        {{- range $.AllTranslations -}}
+        <li {{ if eq $.Lang .Lang }}class="current"{{ end }}>{{ if eq $.Permalink .Permalink }}<span>{{ else }}</a><a href="{{ .RelPermalink }}">{{ end }}{{ .Lang | upper }}{{ if eq $.Permalink .Permalink }}<span>{{ else }}</span>{{ end }}</a></li>
+        {{- end -}}
+    </ul>
+</aside>
+{{ end }}


### PR DESCRIPTION
in this pr:

- refactor language indicator logic from issue list to a partial
- use available languages partial for feature articles and snippets on home page and issue list
- implement dark-background styles for language indicator chips 
- translations for available languages text

testing checklist:
- [x] issue list displays language indicators for each article; see [issue 3](https://startwords-dev-pr-245.onrender.com/issues/3/#features)
- [x] issue list displays language indicators for snippets; see [issue 2](https://startwords-dev-pr-245.onrender.com/issues/2/#features)
- [x] language indicators also display for articles on the [homepage](https://startwords-dev-pr-245.onrender.com/)

design review checklist:
- [x] language chip styles implemented correctly for dark background
- [ ] spacing for language chips correct on feature articles
- [ ] spacing for language chips looks ok for snippets
