### PR TITLE
Display issue credits from default language issue

### DIFF
--- a/content/issues/3/_index.es.md
+++ b/content/issues/3/_index.es.md
@@ -8,19 +8,7 @@ date: 2022-02-01 #TODO: Replace with final publication date
 slug: 3
 num_features: 3
 summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. #TODO: Replace placeholder text
-contributors:
-    - Guest Editor:
-      - Toma Tasovac
-    - Editor:
-      - Grant Wythoff
-    - Technical Lead:
-      - Rebecca Sutton Koeser
-    - Technical:
-      - Kevin McElwee
-    - UX Designer:
-      - Gissoo Doroudian
-    - Manuscript Editing:
-      - Camey VanSant
+
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis commodo odio aenean sed adipiscing diam. In hac habitasse platea dictumst vestibulum rhoncus est pellentesque. Nunc eget lorem dolor sed viverra ipsum nunc. Vestibulum morbi blandit cursus risus at ultrices mi. Euismod nisi porta lorem mollis aliquam ut porttitor leo. A diam maecenas sed enim. Orci porta non pulvinar neque laoreet suspendisse. Pulvinar sapien et ligula ullamcorper malesuada. Purus ut faucibus pulvinar elementum integer enim neque volutpat ac. Metus dictum at tempor commodo. Tempus urna et pharetra pharetra massa massa ultricies mi quis. Quam adipiscing vitae proin sagittis nisl. Ultricies leo integer malesuada nunc. Facilisis volutpat est velit egestas dui id ornare.

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -27,7 +27,7 @@ contributors:
     - Rebecca Sutton Koeser
     - Grant Wythoff
 ```
-For translated issues, the credits should only be added to the issue in the default content language (i.e., English); credits will be displayed and localized on all translated issue pages from the main issue.
+For translated issues, the credits should only be added to the issue in the default content language (i.e., English); credits will be displayed and localized on all translated issue pages from the default / English issue page.
 
 ## Article text version
 

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -27,6 +27,7 @@ contributors:
     - Rebecca Sutton Koeser
     - Grant Wythoff
 ```
+For translated issues, the credits should only be added to the issue in the default content language (i.e., English); credits will be displayed and localized on all translated issue pages from the main issue.
 
 ## Article text version
 

--- a/themes/startwords/layouts/issue/single.html
+++ b/themes/startwords/layouts/issue/single.html
@@ -19,14 +19,29 @@
         </div>
     </div>
     {{ partial "issue/features.html" . }}
-    <section class="grid masthead">
+
+    {{/* get contributor information from current page OR default language issue */}}
+    {{ $credits := newScratch }}
+    {{ if .Params.contributors }}
+        {{ $credits.Set "contributors" .Params.contributors }}
+    {{ else }}
+        {{/* If contributors are not set, get default language version of this page.
+            Since defaultContentLanguage is not accessible; get first language by priority */}}
+        {{ $defaultLang := index .Site.Languages 0 }}
+        {{ with index (where .Translations ".Lang" $defaultLang.Lang) 0 }}
+            {{ $credits.Set "contributors" .Params.contributors }}
+        {{ end }}
+    {{ end }}
+    {{ if $credits.Get "contributors" }}
+    <section class="grid masthead" id="credits">
         <div class="container">
             <h2>{{ i18n "credits" }}</h2>
-                {{ range .Params.contributors }}
+                {{ range $credits.Get "contributors" }}
                     {{ partial "credits.html" . }}
                 {{ end }}
         </div>
     </section>
+    {{ end }}
 
 </main>
 {{ end }}


### PR DESCRIPTION
@gwijthoff  here's my solution to avoid duplicating issue contributors on translated issues:

- when rendering single issue page, if contributors are defined in issue page metadata, they will be displayed
- if no contributors are set, they will be pulled from the default language translation of that issue (i.e., for the spanish version of issue 3 they will be pulled from the english issue 3)

## review checklist:
- [x] template logic makes sense to you 
- [x] same contributors display on english and spanish versions of issue 3
- [x] readme documentation is clear