### PR TITLE
Display fallback untranslated content on homepage & single issue page

### DIFF
--- a/content/issues/3/_index.es.md
+++ b/content/issues/3/_index.es.md
@@ -1,7 +1,7 @@
 ---
 type: issue
 layout: single
-title: Issue Three
+title: Issue Three # TODO: translate
 number: 3
 theme: Loros
 date: 2022-02-01 #TODO: Replace with final publication date

--- a/themes/startwords/layouts/index.html
+++ b/themes/startwords/layouts/index.html
@@ -14,7 +14,9 @@
     </div>
     <div class="issue-summary inverted grid">
         <div class="container">
-            {{ $issue := index (where .Site.AllPages "Type" "issue") 0 }}
+            {{/* get issues for the current language; fill in with all issues; then choose the first. */}}
+            {{ $issues := where .Site.Pages "Type" "issue" | lang.Merge (where .Site.AllPages "Type" "issue") }}
+            {{ $issue := index ($issues) 0 }}
             <span class="number">{{ i18n "issue" }} {{ $issue.Params.number }}</span>
             <h2 class="theme">{{ $issue.Params.theme }}</h2>
             <p class="summary">

--- a/themes/startwords/layouts/issue/list.html
+++ b/themes/startwords/layouts/issue/list.html
@@ -6,21 +6,18 @@
         <div class="container">
             {{ with .Title }}<h1 class="sr-only">{{ . }}</h1>{{ end }}
             {{ with .Content }}{{ . }}{{ end }}
-            {{/* get all issues in any language */}}
-            {{ $issues := where (where .Site.AllPages "Type" "issue") ".Params.number" "gt" 0 }}
+            {{/* get all issues in current language; supplement from main language where missing */}}
+            {{ $issues := where .Pages "Type" "issue" | lang.Merge (where (where .Site.AllPages "Type" "issue") ".Params.number" "gt" 0) }}
             {{ $currentLang := .Site.Language.Lang }}
             {{ if $issues }}
             <ol>
                 {{ range $issues }}
-                {{/* don't show translated issue if available in the current language */}}
-                {{ if not (where .Translations ".Lang" $currentLang) }}
                 <li {{ if not (eq .Lang $currentLang )}}lang="{{ .Lang }}"{{ end }}> {{/* set language if it changes */}}
                     <a class="highlight-focus" href="{{ .RelPermalink }}" aria-label="{{ i18n "issue" }} {{ .Params.number }}">
                         {{ .Render "summary" }}
                     </a>
                    {{ partial "available_languages.html" . }}
                 </li>
-                {{ end }}
                 {{ end }}
             </ol>
             {{ else }}

--- a/themes/startwords/layouts/partials/issue/features.html
+++ b/themes/startwords/layouts/partials/issue/features.html
@@ -1,12 +1,26 @@
 <section id="features" aria-label="{{ i18n "features" }}" class="inverted grid">
     <div class="wide-container">
         {{/* display feature essays; two by default, but overridable in issue params */}}
+
+        {{/* get articles for the current issue */}}
+        {{ $pages := newScratch }}
+        {{ $currentArticles := .Pages.ByParam "order" }}
+        {{ $pages.Set "articles" $currentArticles }}
+        {{/* if this issue is translated, get articles from main language issue to supplement any untranslated content */}}
+        {{ if .IsTranslated }}
+            {{ $defaultLang := index .Site.Languages 0 }}
+            {{ $mainLangIssue := index (where .Translations ".Lang" $defaultLang.Lang) 0 }}
+            {{ $pages.Set "articles" ($currentArticles | lang.Merge ($mainLangIssue.Pages.ByParam "order")) }}
+        {{ end }}
+        {{/* order the merged set so mixed language articles will sort properly */}}
+        {{ $articles := sort ($pages.Get "articles")  ".Params.order" }}
+
         {{ $numFeatures := default 2 (int .Params.num_features) }}
-        {{ range first $numFeatures (.Pages.ByParam "order") }}
+        {{ range first $numFeatures  $articles }}
             {{ .Render "summary" }}
         {{ end }}
         {{/* display snippets, if any; any articles after the features */}}
-        {{ $snippets := after $numFeatures (.Pages.ByParam "order") }}
+        {{ $snippets := after $numFeatures $articles }}
         {{ if $snippets }}
         <div class="snippets">
             <h2>{{ i18n "snippets" }}</h2>


### PR DESCRIPTION
in this pr:
- revise homepage template to correctly choose current issue for translated site
- use [`lang.Merge`](https://gohugo.io/functions/lang.merge/) to properly fill in for untranslated content on single issue page (article list) and issue list (simplifies existing logic)

testing instructions:
- [x] confirm [english home page](https://startwords-dev-pr-267.onrender.com/) lists all three articles in english
- [x] confirm [spanish home page](https://startwords-dev-pr-267.onrender.com/es/) lists all three articles; article should be in spanish when available
- [x] confirm [spanish version of issue 3](https://startwords-dev-pr-267.onrender.com/es/issues/3/) lists all three articles; should be in spanish when available
- [x] confirm [english version of issue 3[(https://startwords-dev-pr-267.onrender.com/issues/3/) lists all three articles in english