### PR TITLE
revised text shadow for feature hook 

### DIFF
--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -95,14 +95,14 @@ $preview-height-xl: rem(250px);  // 1024px-
         left: 0;  // attach to left of viewport; keep fixed with text vertically
         width: 100%;
         color: $light-purple;
-        opacity: 0.1;
+        opacity: 10%;
         pointer-events: none;
 
         // use scale for sizing to ensure text shape matches visible summary
         // scale relative to initial font size of 1rem (18px)
 
         // on mobile, position 21px above corresponding summary text
-        // desired font size is 19px; original mobile font size is 16, so 1.18
+        // desired font size is 19px; original mobile font size is 16, so 1.18x
         transform: translate(0, -21px) scale(1.18);
         // set transform origin relative to left so that scaling will not move off-screen
         transform-origin: left top;
@@ -110,26 +110,26 @@ $preview-height-xl: rem(250px);  // 1024px-
         // shift to desktop styles at the breakpoint where summaries are not attached to viewport edge
         @media (min-width: $breakpoint-s) {
             // position 108px above corresponding summary text
-            // desired font size is 32px = 1.8x
+            // desired font size is 32px, relative to 18x base font size is 1.8x
             transform: translate(0, -108px) scale(1.8);
         }
-
     }
 
-    // for debugging
-    /*p {
-        opacity: 0.5;
-    }
-    .bg-text {
-        color: gray !important;
-    }*/
+    // secondary shadow is even larger and more transparent
+    .bg-text.secondary {
+        opacity: 3%;
+        // on mobile, position 49px above corresponding summary text
+        // desired font size is 32px; original mobile font size is 16, so 2x
+        transform: translate(0, -49px) scale(2);
 
-    // text-shaping elements
-    /*
-    .bg-text::before {
-        content: '';
-        width: 100%;
-    }*/
+        // shift to desktop styles at the breakpoint where summaries are not attached to viewport edge
+        @media (min-width: $breakpoint-s) {
+            // position 170px above corresponding summary text
+            // shift left (text begins off screen)
+            // desired font size is 54px, relative to 18x base font size is 3x
+            transform: translate(-28px, -170px) scale(3);
+        }
+    }
 
     // scale the polygon shape based on screen width
     p span, .bg-text span {

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -31,7 +31,7 @@ $preview-height-xl: rem(250px);  // 1024px-
         text-decoration: none;
     }
 
-    p {
+    p, .bg-text {
         margin: 0;
         line-height: rem(22px);
         max-width: rem(200px);
@@ -40,15 +40,16 @@ $preview-height-xl: rem(250px);  // 1024px-
         @media (min-width: $breakpoint-m) { font-size: rem(18px); }
     }
 
+
     // height must be set for shape-outside text flow;
     // spacer height is set in hugo template based on content length
-    p span {
+    .shaper {
         width: 60%;
         float: right;
         display: block;
     }
 
-
+    /*
     .bg-text,
     .bg-text::before {
         height: calc(#{$preview-height-xs} * 1.5);
@@ -56,7 +57,7 @@ $preview-height-xl: rem(250px);  // 1024px-
         @media (min-width: 414px) { height: calc(#{$preview-height-m} * 1.5); }
         @media (min-width: $breakpoint-s) { height: calc(#{$preview-height-l} * 1.5); }
         @media (min-width: $breakpoint-m) { height: calc(#{$preview-height-xl} * 1.5); }
-    }
+    }*/
 
     h2 {
         font-family: $font-sans;
@@ -91,19 +92,32 @@ $preview-height-xl: rem(250px);  // 1024px-
     // background text
     .bg-text {
         position: absolute;
-        width: 48vw;
+        left: 0;
+        top: 0;
+        /*width: 48vw; */
+        width: 100%;
         color: rgba(224, 206, 255, 0.05);
-        top: rem(-50px);
-        font-size: rem(20px);
+        // top: rem(-50px);
+        // font-size: rem(20px);
         pointer-events: none;
-        @media (min-width: $breakpoint-s) { font-size: rem(30px); }
+        // @media (min-width: $breakpoint-s) { font-size: rem(30px); }
+        transform: translate(-175px, 0) scale(1.5);
     }
 
+    // for debugging
+    /*p {
+        opacity: 0.5;
+    }
+    .bg-text {
+        color: gray !important;
+    }*/
+
     // text-shaping elements
+    /*
     .bg-text::before {
         content: '';
         width: 100%;
-    }
+    }*/
 
     // scale the polygon shape based on screen width
     p span {
@@ -126,7 +140,7 @@ $preview-height-xl: rem(250px);  // 1024px-
         }
 
 
-        p span {
+        .shaper {
             float: right;
             shape-outside: $curve-left;
             /* turn on clip-path to view the shape for debugging
@@ -141,10 +155,10 @@ $preview-height-xl: rem(250px);  // 1024px-
             }
 
         }
-        .bg-text::before {
+        /*.bg-text::before {
             float: right;
             shape-outside: $triangle-left;
-        }
+        }*/
     }
 
     // right summaries
@@ -159,7 +173,7 @@ $preview-height-xl: rem(250px);  // 1024px-
 
         p { margin-left: auto; }
 
-        p span {
+        .shaper {
             float: left;
             /* turn on clip-path to view the shape for debugging
             clip-path: $curve-right;
@@ -173,9 +187,12 @@ $preview-height-xl: rem(250px);  // 1024px-
 
             }
         }
-        .bg-text::before {
-            float: left;
-            shape-outside: $triangle-right;
+
+
+        .bg-text {
+            right: 0;
+            left: auto;
+            transform: translate(175px, 0) scale(1.5);;
         }
     }
 
@@ -183,8 +200,18 @@ $preview-height-xl: rem(250px);  // 1024px-
     //  (i.e., 2nd article summary is also the 2nd to last article summary).
     &:nth-of-type(2):nth-last-of-type(2) {
         padding-top: 12em;
+
+        // adjust background text so it is aligned with main text
+        .bg-text {
+            top: 12em;
+        }
+
         @media (min-width: $breakpoint-s) {
             padding-top: 10em;
+
+            .bg-text {
+                top: 10em;
+            }
         }
     }
 

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -49,16 +49,6 @@ $preview-height-xl: rem(250px);  // 1024px-
         display: block;
     }
 
-    /*
-    .bg-text,
-    .bg-text::before {
-        height: calc(#{$preview-height-xs} * 1.5);
-        @media (min-width: 375px) { height: calc(#{$preview-height-s} * 1.5); }
-        @media (min-width: 414px) { height: calc(#{$preview-height-m} * 1.5); }
-        @media (min-width: $breakpoint-s) { height: calc(#{$preview-height-l} * 1.5); }
-        @media (min-width: $breakpoint-m) { height: calc(#{$preview-height-xl} * 1.5); }
-    }*/
-
     h2 {
         font-family: $font-sans;
         font-weight: bold;
@@ -120,13 +110,13 @@ $preview-height-xl: rem(250px);  // 1024px-
         opacity: 3%;
         // on mobile, position 49px above corresponding summary text
         // desired font size is 32px; original mobile font size is 16, so 2x
-        transform: translate(0, -49px) scale(2);
+        transform: translate(-14px, -49px) scale(2);
 
         // shift to desktop styles at the breakpoint where summaries are not attached to viewport edge
         @media (min-width: $breakpoint-s) {
             // position 170px above corresponding summary text
             // shift left (text begins off screen)
-            // desired font size is 54px, relative to 18x base font size is 3x
+            // desired font size is 54px, relative to 16x base font size is 3x
             transform: translate(-28px, -170px) scale(3);
         }
     }

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -212,12 +212,17 @@ $preview-height-xl: rem(250px);  // 1024px-
     &:nth-of-type(1):nth-last-of-type(3) {
         margin-top: rem(62px);
     }
-    /* add spacing to any summary that comes after th first in a column */
+    /* add spacing to any summary that comes after the first in a column */
     &:nth-child(n+3) {
         margin-top: rem(96px);
         @media (min-width: $breakpoint-s) {
             margin-top: rem(124px);
         }
+    }
+
+    // adjust spacing for last summary when there are three
+    &:nth-of-type(3):nth-last-of-type(1) {
+        margin-bottom: rem(62px);
     }
 
     // inverted portions use light purple instead of white

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -22,7 +22,7 @@ $preview-height-xl: rem(250px);  // 1024px-
     width: 48%;  /* leave some space between columns */
     font-size: rem(16px);
     font-family: $font-sans;
-    position: relative;
+    // position: relative;   /* remove so bg-text can be positioned absolutely outside the summary */
     z-index: 1;
 
     @media (min-width: $breakpoint-m) { font-size: rem(18px); }
@@ -92,16 +92,28 @@ $preview-height-xl: rem(250px);  // 1024px-
     // background text
     .bg-text {
         position: absolute;
-        left: 0;
-        top: 0;
-        /*width: 48vw; */
+        left: 0;  // attach to left of viewport; keep fixed with text vertically
         width: 100%;
-        color: rgba(224, 206, 255, 0.05);
-        // top: rem(-50px);
-        // font-size: rem(20px);
+        color: $light-purple;
+        opacity: 0.1;
         pointer-events: none;
-        // @media (min-width: $breakpoint-s) { font-size: rem(30px); }
-        transform: translate(-175px, 0) scale(1.5);
+
+        // use scale for sizing to ensure text shape matches visible summary
+        // scale relative to initial font size of 1rem (18px)
+
+        // on mobile, position 21px above corresponding summary text
+        // desired font size is 19px; original mobile font size is 16, so 1.18
+        transform: translate(0, -21px) scale(1.18);
+        // set transform origin relative to left so that scaling will not move off-screen
+        transform-origin: left top;
+
+        // shift to desktop styles at the breakpoint where summaries are not attached to viewport edge
+        @media (min-width: $breakpoint-s) {
+            // position 108px above corresponding summary text
+            // desired font size is 32px = 1.8x
+            transform: translate(0, -108px) scale(1.8);
+        }
+
     }
 
     // for debugging
@@ -120,7 +132,7 @@ $preview-height-xl: rem(250px);  // 1024px-
     }*/
 
     // scale the polygon shape based on screen width
-    p span {
+    p span, .bg-text span {
         --h: 1;
 
         @media (min-width: $breakpoint-s) { --h: 1.2; }
@@ -136,7 +148,6 @@ $preview-height-xl: rem(250px);  // 1024px-
 
         .bg-text {
             text-align: left;
-            right: 0;
         }
 
 
@@ -155,10 +166,7 @@ $preview-height-xl: rem(250px);  // 1024px-
             }
 
         }
-        /*.bg-text::before {
-            float: right;
-            shape-outside: $triangle-left;
-        }*/
+
     }
 
     // right summaries
@@ -167,10 +175,6 @@ $preview-height-xl: rem(250px);  // 1024px-
         text-align: right;
         margin-top: rem(40px);
 
-        .bg-text {
-            left: 0;
-        }
-
         p { margin-left: auto; }
 
         .shaper {
@@ -178,21 +182,19 @@ $preview-height-xl: rem(250px);  // 1024px-
             /* turn on clip-path to view the shape for debugging
             clip-path: $curve-right;
             background-color: white;
-            opacity: 0.1;*/
+            opacity: 0.1; */
 
             shape-outside: $curve-right;
             @media (min-width: $breakpoint-s) {
                shape-outside: $curve-right-desktop;
                clip-path: $curve-right-desktop;
-
             }
         }
 
-
         .bg-text {
-            right: 0;
+            right: 0;  // attach to right side of screen instead of left
             left: auto;
-            transform: translate(175px, 0) scale(1.5);;
+            transform-origin: right top;  // scale relative to right side
         }
     }
 
@@ -201,17 +203,8 @@ $preview-height-xl: rem(250px);  // 1024px-
     &:nth-of-type(2):nth-last-of-type(2) {
         padding-top: 12em;
 
-        // adjust background text so it is aligned with main text
-        .bg-text {
-            top: 12em;
-        }
-
         @media (min-width: $breakpoint-s) {
             padding-top: 10em;
-
-            .bg-text {
-                top: 10em;
-            }
         }
     }
 

--- a/themes/startwords/assets/scss/issue/_single.scss
+++ b/themes/startwords/assets/scss/issue/_single.scss
@@ -1,5 +1,13 @@
 /* single issue page styles */
 
+/* secondary shadow text runs off the page, which makes
+   the page horizontally scrollable on iOS; disable that here */
+html, body {
+    position: relative;
+    overflow-x: hidden;
+    max-width: 100vw;
+}
+
 body.issue {
     // issue summary display similar to homepage
     .issue-summary {

--- a/themes/startwords/layouts/article/summary.html
+++ b/themes/startwords/layouts/article/summary.html
@@ -1,10 +1,11 @@
 <article class="article-summary">
     {{ $summaryText := .Summary | plainify }}
-    <div class="bg-text" role="presentation">{{ $summaryText }}</div>
+    {{ $shaperHeight := .Params.hook_height_override | default (mul 1.45  ($summaryText | countrunes) | lang.FormatNumber 3) }}
+    <div class="bg-text" role="presentation"><span class="shaper" style="height:{{ $shaperHeight }}px"></span>{{ $summaryText }}</div>
     {{/* output length + wordcount in case it is helpful to editors/devs adjusting height */}}
     <!-- summary length: {{ $summaryText | len }}; rune count: {{ $summaryText | countrunes }}; word count: {{ $summaryText | countwords }}-->
     {{/* use override param if set; otherwise calculate based on text length; length * 1.25; runecount * 1.4   */}}
-    <p><span style="height:{{ .Params.hook_height_override | default (mul 1.45  ($summaryText | countrunes) | lang.FormatNumber 3) }}px"></span>{{ $summaryText }}</p>
+    <p><span class="shaper" style="height:{{ $shaperHeight }}px"></span>{{ $summaryText }}</p>
     <h2><a class="highlight-focus" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
     {{ partial "available_languages.html" . }}
     {{ partial "authors" . }}

--- a/themes/startwords/layouts/article/summary.html
+++ b/themes/startwords/layouts/article/summary.html
@@ -2,6 +2,7 @@
     {{ $summaryText := .Summary | plainify }}
     {{ $shaperHeight := .Params.hook_height_override | default (mul 1.45  ($summaryText | countrunes) | lang.FormatNumber 3) }}
     <div class="bg-text" role="presentation"><span class="shaper" style="height:{{ $shaperHeight }}px"></span>{{ $summaryText }}</div>
+    <div class="bg-text secondary" role="presentation"><span class="shaper" style="height:{{ $shaperHeight }}px"></span>{{ $summaryText }}</div>
     {{/* output length + wordcount in case it is helpful to editors/devs adjusting height */}}
     <!-- summary length: {{ $summaryText | len }}; rune count: {{ $summaryText | countrunes }}; word count: {{ $summaryText | countwords }}-->
     {{/* use override param if set; otherwise calculate based on text length; length * 1.25; runecount * 1.4   */}}


### PR DESCRIPTION
Very excited to share the new version of the shadow text for the feature article opening lines.

Please review all issues on a variety of screen sizes:
- [homepage](https://startwords-dev-pr-269.onrender.com/)
- [issue 3 features](https://startwords-dev-pr-269.onrender.com/issues/3/#features)
- [issue 2 features](https://startwords-dev-pr-269.onrender.com/issues/2/#features)
- [issue 1 features](https://startwords-dev-pr-269.onrender.com/issues/1/#features)

I've also added some space after the third feature on issue 3 since there are no snippets.
