### PR TITLE
Update footer config & styles to add Authors page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,10 @@ menu:
     - name: About
       url: about/
       weight: 20
+    - name: Authors
+      url: authors/
+      weight: 30
+
 
 Author:
   name: Center for Digital Humanities at Princeton
@@ -79,6 +83,10 @@ languages:
         - name: Acerca de
           url: /es/acerca-de/
           weight: 20
+        - name: Authors
+          url: authors/
+          weight: 30
+
 
 markup:
   goldmark:

--- a/themes/startwords/assets/scss/_footer.scss
+++ b/themes/startwords/assets/scss/_footer.scss
@@ -29,7 +29,24 @@ body > footer {
         clip-path: polygon(calc(100vw - 60px) 0, 100% 27%, 100% 100%, 0 100%);
     }
 
-    nav { position: relative; }
+    nav {
+        position: absolute;
+        bottom: rem(10px);
+        right: rem(8px);
+
+        @media (min-width: $breakpoint-s) {
+            right: rem(30px);
+            bottom: rem(15px);
+        }
+
+        ul {
+            padding: 0;
+        }
+        li {
+            text-align: left;
+            padding-top: rem(8px);
+        }
+    }
 
     &.inverted {  @include inverted-footer; }
 
@@ -55,12 +72,14 @@ body > footer {
 
     .icons {
         position: absolute;
-        right: rem(45px);
+        right: rem(93px);
         bottom: rem(10px);
+        min-width: 136px;  /* don't let the icons div wrap */
 
-        @media (min-width: $breakpoint-s) { bottom: rem(15px); }
-        @media (min-width: $breakpoint-m) { bottom: rem(10px); }
-
+        @media (min-width: $breakpoint-s) {
+            right: rem(130px);
+            bottom: rem(15px);
+        }
 
         .logo {
             mask-size: contain;

--- a/themes/startwords/assets/scss/_footer.scss
+++ b/themes/startwords/assets/scss/_footer.scss
@@ -8,7 +8,7 @@ body > footer {
     width: 100vw;
     bottom: 0;
     text-align: right;
-    font-weight: 300;
+    font-weight: 400;
     font-size: rem(16px);
     position: relative;
     background: $off-white;

--- a/themes/startwords/assets/scss/_footer.scss
+++ b/themes/startwords/assets/scss/_footer.scss
@@ -47,7 +47,7 @@ body > footer {
 
             a {
                 display: inline-block;
-                padding-top: rem(8px);
+                margin-top: rem(8px);
             }
         }
     }

--- a/themes/startwords/assets/scss/_footer.scss
+++ b/themes/startwords/assets/scss/_footer.scss
@@ -44,7 +44,11 @@ body > footer {
         }
         li {
             text-align: left;
-            padding-top: rem(8px);
+
+            a {
+                display: inline-block;
+                padding-top: rem(8px);
+            }
         }
     }
 

--- a/themes/startwords/assets/scss/_i18n.scss
+++ b/themes/startwords/assets/scss/_i18n.scss
@@ -106,6 +106,7 @@ aside.translations {
         margin-right: 0.5rem;
         width: 1.7rem;
         height: 1.3rem;
+        line-height: 1.3rem;
         background: white;
         border: 2px solid $purple;
         border-radius: 4px;

--- a/themes/startwords/assets/scss/authors/_list.scss
+++ b/themes/startwords/assets/scss/authors/_list.scss
@@ -103,7 +103,7 @@ body.authors {
     }
 
     .languages {
-        margin-bottom: rem(8px);
+        margin-bottom: rem(4px);
         span {
             border: 1px solid $dark-purple;
         }


### PR DESCRIPTION
ref #268

in this PR:
- revise menu configuration in site config to add Authors after About
- adjust footer styles per Gissoo's designs to accommodate displaying both Authors and About

Note: I thought it was better for the Spanish site menu to be consistent with the English site, so I included the English site Authors link in the Spanish menu. Open to other ideas if you prefer something else (but if we only have one item in the menu the styles will probably need some adjustment).