### PR TITLE
Adjust text container to avoid indentation bug

### DIFF
--- a/themes/startwords/assets/scss/_utilities.scss
+++ b/themes/startwords/assets/scss/_utilities.scss
@@ -30,7 +30,11 @@
     > .text-container {
         grid-column: 1 / 11;
         @media (min-width: $breakpoint-s) { grid-column: 2 / 10; }
-        @media (min-width: $breakpoint-m) { grid-column: 3 / 9; }
+        @media (min-width: $breakpoint-m) {
+            grid-column: 3 / 9;
+            /* don't allow to grow wider than the grid (e.g., embedded videos) */
+            max-width: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
ref #264

Figured it out! I noticed it was happening on Firefox and not Chrome, which made me think it was a sizing issue — on FF the video was stretching the size of the container, which resulted in the centered text in the stretched container not matching the centered text of the header container, which was not getting stretched.

Please confirm:

https://startwords-dev-pr-283.onrender.com/issues/2/datas-destinations/