### PR TITLE
Make links visible in issue introduction

### DIFF
--- a/themes/startwords/assets/scss/issue/_single.scss
+++ b/themes/startwords/assets/scss/issue/_single.scss
@@ -20,10 +20,11 @@ body.issue {
             & > p { margin-top: rem(5px); }
 
             // introduction authors
-            address {
-            display: inline;
-            font-style: normal;
-            color: $black;
+            address, .authors a {
+                display: inline;
+                font-style: normal;
+                color: $black;
+                text-decoration: none;
             }
 
             .translators {

--- a/themes/startwords/assets/scss/issue/_single.scss
+++ b/themes/startwords/assets/scss/issue/_single.scss
@@ -20,7 +20,7 @@ body.issue {
             & > p { margin-top: rem(5px); }
 
             // introduction authors
-            a, address {
+            address {
             display: inline;
             font-style: normal;
             color: $black;

--- a/themes/startwords/assets/scss/issue/_summary.scss
+++ b/themes/startwords/assets/scss/issue/_summary.scss
@@ -16,7 +16,6 @@
         .theme, .theme a { color: $light-purple; }
     }
 
-    a:not(.more) { text-decoration: none; }
     .more { font-size: rem(16px); }
 
     .number,
@@ -27,7 +26,7 @@
 
     .theme {
         font-size: rem(20px);
-        margin: rem(5px) 0 0;  
+        margin: rem(5px) 0 0;
         line-height: normal;
         @media (min-width: $breakpoint-m) { font-size: rem(22px); }
 
@@ -45,7 +44,7 @@
         line-height: rem(25px);
         @media (min-width: $breakpoint-m) { line-height: rem(27px); }
     }
-    
+
     .number, .more {
         @media (min-width: $breakpoint-m) { font-size: rem(18px); }
     }

--- a/themes/startwords/layouts/partials/intro-authors.html
+++ b/themes/startwords/layouts/partials/intro-authors.html
@@ -16,9 +16,9 @@
 {{- $author_count := (len $authors) -}}
 <div class="authors">— 
 {{ range $index, $author := $authors }}
-    {{- if $index -}} {{/* add delimiters when after first author */}}
-    {{- if eq (add $index 1) $author_count -}} {{ i18n "and" }} {{ else }}, {{ end -}}
-    {{- end -}}
+    {{ if $index }} {{/* add delimiters when after first author */}}
+    {{ if eq (add $index 1) $author_count }} {{ i18n "and" }} {{ else }}, {{ end }}
+    {{ end }}
     {{ $info := index $.Site.Data.authors $author }} {{/* get author info */}}
     {{/* display name from param as fallback if there is no entry in the authors data file */}}
     {{ if $info }}<a href="{{ relURL "/authors/" }}#{{ . }}">{{ end }}<address>{{ $info.name | default . }}</address>{{ if $info }}</a>{{ end }}


### PR DESCRIPTION
ref #286

review issue 3 introduction: https://startwords-dev-pr-290.onrender.com/issues/3/
- [x] links in text are visibly styled as links
- [x] issue introduction authors are not styled as links

I don't know what's going on with the missing space between author names on render, I think maybe it's render specific and will look ok on github....