### PR TITLE
Update author citation to use authors data file

### DIFF
--- a/content/issues/1/_index.md
+++ b/content/issues/1/_index.md
@@ -8,7 +8,7 @@ date: 2020-10-01
 slug: 1
 summary: Every day, countless decisions are quietly made on the basis of data most of us will never touch.
 authors:
-  - wythoffgrant
+  - WythoffGrant
 contributors:
     - Editor:
       - Grant Wythoff

--- a/content/issues/1/data-beyond-vision/index.md
+++ b/content/issues/1/data-beyond-vision/index.md
@@ -3,10 +3,10 @@ type: article
 title: Data Beyond Vision
 order: 1
 authors:
-  - koeserrebecca
-  - doroudiangissoo
-  - budaknick
-  - lixinyi
+  - KoeserRebeccaSutton
+  - DoroudianGissoo
+  - BudakNick
+  - LiXinyi
 date: 2020-10-01
 doi: 10.5281/zenodo.3713670
 pdf: https://zenodo.org/record/4139781/files/startwords-1-data-beyond-vision.pdf

--- a/content/issues/1/print-model/index.md
+++ b/content/issues/1/print-model/index.md
@@ -3,7 +3,7 @@ type: article
 title: Print a Model of the Shakespeare and Company Lending Library Membership
 order: 3
 authors:
-  - koeserrebecca
+  - KoeserRebeccaSutton
 date: 2020-10-01
 tags: [DataBeyondVision, HowTo]
 slug: modeling-howto

--- a/content/issues/1/stack-membership-activities/index.md
+++ b/content/issues/1/stack-membership-activities/index.md
@@ -4,8 +4,8 @@ title: Stack Shakespeare and Company Membership Activities
 slug: stacking-howto
 order: 5
 authors:
-  - lixinyi
-  - koeserrebecca
+  - LiXinyi
+  - KoeserRebeccaSutton
 date: 2020-10-01
 tags: [DataBeyondVision, HowTo]
 images: ["issues/1/stacking-howto/images/stacking-preview.jpg"]

--- a/content/issues/1/their-data-ourselves/index.md
+++ b/content/issues/1/their-data-ourselves/index.md
@@ -5,7 +5,7 @@ title: |
   Their Data, Ourselves: Illness as Information
 order: 2
 authors:
-    - munsonrebecca
+    - MunsonRebecca
 date: 2020-10-01
 doi: 10.5281/zenodo.3713678
 pdf: https://zenodo.org/record/3713678/files/their-data-ourselves.pdf

--- a/content/issues/1/weave-references/index.md
+++ b/content/issues/1/weave-references/index.md
@@ -4,7 +4,7 @@ title: Weave Derrida's References
 slug: weaving-howto
 order: 4
 authors:
-  - doroudiangissoo
+  - DoroudianGissoo
 date: 2020-10-01
 tags: [DataBeyondVision, HowTo]
 images: ["issues/1/weaving-howto/images/weaving-preview.jpg"]

--- a/content/issues/1/weaving-interface/index.md
+++ b/content/issues/1/weaving-interface/index.md
@@ -3,8 +3,8 @@ type: article
 title: Weaving as Interface
 order: 6
 authors:
-  - koeserrebecca
-  - doroudiangissoo
+  - KoeserRebeccaSutton
+  - DoroudianGissoo
 tags: [DataBeyondVision, Experiment]
 needs_deepzoom: true
 body_class: darkmode

--- a/content/issues/2/_index.md
+++ b/content/issues/2/_index.md
@@ -8,7 +8,7 @@ date: 2021-12-01
 slug: 2
 summary: Between the ninth and nineteenth centuries, community members in Fustat, Egypt discarded textual materials in a storeroom (or ‘geniza’) of the Ben Ezra synagogue.
 authors:
-  - estenemily
+  - EstenEmily
 contributors:
     - Guest Editor:
       - Emily Esten

--- a/content/issues/2/creating-and-recreating-virtual-community/index.md
+++ b/content/issues/2/creating-and-recreating-virtual-community/index.md
@@ -4,9 +4,9 @@ slug: 'creating-and-recreating-virtual-community'
 title: Creating and Recreating Virtual Community on Douglass Day
 order: 3
 authors:
-    - smithjustin
-    - murraycourtney
-    - caseyjim
+    - SmithJustin
+    - MurrayCourtney
+    - CaseyJim
 date: 2021-12-01
 doi: 10.5281/zenodo.5750693
 pdf: https://zenodo.org/record/5750693/files/startwords-2-creating-and-recreating-virtual-community.pdf

--- a/content/issues/2/datas-destinations/index.md
+++ b/content/issues/2/datas-destinations/index.md
@@ -5,8 +5,8 @@ title: |
   Data's Destinations: Three Case Studies in Crowdsourced Transcription Data Management and Dissemination
 order: 2
 authors:
-    - vanhyningvictoriaanne
-    - jonesmasona
+    - VanHyningVictoriaAnne
+    - JonesMasonA
 date: 2021-12-01
 doi: 10.5281/zenodo.5750691
 pdf: https://zenodo.org/record/5750691/files/startwords-2-datas-destinations.pdf

--- a/content/issues/2/serendipity-in-the-cairo-geniza/index.md
+++ b/content/issues/2/serendipity-in-the-cairo-geniza/index.md
@@ -4,8 +4,8 @@ slug: 'serendipity-in-the-cairo-geniza'
 title: Serendipity in the Cairo Geniza
 order: 4
 authors:
-    - dudleymatthew
-    - readersteffy
+    - DudleyMatthew
+    - ReaderSteffy
 date: 2021-12-01
 doi: 10.5281/zenodo.5750695
 pdf: https://zenodo.org/record/5750695/files/startwords-2-serendipity-in-the-cairo-geniza.pdf

--- a/content/issues/2/strangers-in-the-landscape/index.md
+++ b/content/issues/2/strangers-in-the-landscape/index.md
@@ -5,10 +5,10 @@ title: |
   “Strangers in the Landscape”: On Research Development and Making Things for Making
 order: 1
 authors:
-    - blickhansamantha
-    - grangerwill
-    - noordinshauna
-    - rotherbecky
+    - BlickhanSamantha
+    - GrangerWill
+    - NoordinShaunA
+    - RotherBecky
 date: 2021-12-01
 doi: 10.5281/zenodo.5750679
 pdf: https://zenodo.org/record/5750679/files/startwords-2-strangers-in-the-landscape.pdf

--- a/content/issues/3/_index.md
+++ b/content/issues/3/_index.md
@@ -9,8 +9,8 @@ slug: 3
 num_features: 3
 summary: "By the time Emily Bender, Timnit Gebru, Angelina McMillan-Major and Margaret Mitchell’s paper “On the Dangers of Stochastic Parrots: Can Language Models Be Too Big?” was published in March 2021, it had already been shaking up the AI world for some time."
 authors:
-    - tasovactoma
-    - ermolaevnatalia
+    - TasovacToma
+    - ErmolaevNatalia
 contributors:
     - Editor:
       - Grant Wythoff

--- a/content/issues/3/llm-limit-case/index.md
+++ b/content/issues/3/llm-limit-case/index.md
@@ -5,7 +5,7 @@ title: |
   Are Large Language Models Our Limit Case?
 order: 3
 authors:
-    - kleinlauren
+    - KleinLauren
 date: 2022-02-01
 doi: 10.5281/zenodo.6567985
 pdf: https://zenodo.org/record/5750691/files/startwords-2-datas-destinations.pdf #TODO: replace PDF

--- a/content/issues/3/mapping-latent-spaces/index.md
+++ b/content/issues/3/mapping-latent-spaces/index.md
@@ -5,7 +5,7 @@ title: |
   Mapping the Latent Spaces of Culture
 order: 1
 authors:
-    - underwoodted
+    - UnderwoodTed
 date: 2022-02-01
 doi: 10.5281/zenodo.6567481
 pdf: https://zenodo.org/record/5750691/files/startwords-2-datas-destinations.pdf #TODO: replace PDF

--- a/content/issues/3/on-spanish-parrots/index.en.md
+++ b/content/issues/3/on-spanish-parrots/index.en.md
@@ -5,7 +5,7 @@ title: |
   On Spanish-Speaking Parrots
 order: 2
 authors:
-    - delrioriandegimena
+    - delRioRiandeGimena
 date: 2022-02-01
 doi: 10.5281/zenodo.6567850
 pdf: https://zenodo.org/record/5750691/files/startwords-2-datas-destinations.pdf #TODO: replace PDF

--- a/content/issues/3/on-spanish-parrots/index.es.md
+++ b/content/issues/3/on-spanish-parrots/index.es.md
@@ -5,7 +5,7 @@ title: |
   Sobre los loros que hablan español
 order: 2
 authors:
-    - delrioriandegimena
+    - delRioRiandeGimena
 date: 2022-02-01
 doi: 10.5281/zenodo.6567966
 pdf: https://zenodo.org/record/5750691/files/startwords-2-datas-destinations.pdf #TODO: replace PDF

--- a/data/authors.yml
+++ b/data/authors.yml
@@ -12,6 +12,7 @@ UnderwoodTed:
   website: https://tedunderwood.com/
 delRioRiandeGimena:
   name: Gimena del Rio Riande
+  sort_name: del Rio Riande, Gimena
   title: Investigadora Asociada del Consejo Nacional de Investigaciones Científicas y Técnicas [Associate Researcher at the National Scientific and Technical Research Council]
   affiliation: CONICET, Argentina
   orcid: 0000-0002-8997-5415
@@ -46,6 +47,7 @@ CaseyJim:
   website: https://jim-casey.com/
 VanHyningVictoriaAnne:
   name: Victoria Anne Van Hyning
+  sort_name: Van Hyning, Victoria Anne
   title: Assistant Professor of Library Innovation
   affiliation: University of Maryland, College of Information Studies
   orcid: 0000-0001-6775-2870

--- a/data/authors.yml
+++ b/data/authors.yml
@@ -1,112 +1,112 @@
-kleinlauren:
+KleinLauren:
   name: Lauren Klein
   title: Winship Distinguished Research Professor and Associate Professor
   affiliation: Emory University
   orcid:  0000-0002-1511-0910
   website: https://lklein.com/
-underwoodted:
+UnderwoodTed:
   name: Ted Underwood
   title: Professor and Associate Dean for Academic Affairs
   affiliation: University of Illinois Urbana-Champaign, School of Information Sciences
   orcid: 0000-0001-8960-1846
   website: https://tedunderwood.com/
-delrioriandegimena:
+delRioRiandeGimena:
   name: Gimena del Rio Riande
   title: Investigadora Asociada del Consejo Nacional de Investigaciones Científicas y Técnicas [Associate Researcher at the National Scientific and Technical Research Council]
   affiliation: CONICET, Argentina
-  orcid: 0000-0002-8997-5415 
+  orcid: 0000-0002-8997-5415
   website: https://www.aacademica.org/gimena.delrio.riande
-tasovactoma:
+TasovacToma:
   name: Toma Tasovac
   title: Director
   affiliation: DARIAH
   orcid: 0000-0002-3919-993X
-ermolaevnatalia:
+ErmolaevNatalia:
   name: Natalia Ermolaev
   title: Associate Director
   affiliation: Center for Digital Humanities at Princeton
-  orcid: 
-estenemily:
+  orcid:
+EstenEmily:
   name: Emily Esten
   title: Arnold and Deanne Kaplan Collection of Early American Judaica Curator of Digital Humanities
   affiliation: University of Pennsylvania Libraries
   orcid: 0000-0002-1120-1698
-smithjustin:
+SmithJustin:
   name: Justin Smith
   title: PhD Candidate
   affiliation: The Pennsylvania State University
-murraycourtney:
+MurrayCourtney:
   name: Courtney Murray
   title: PhD Candidate
   affiliation: The Pennsylvania State University
-caseyjim:
+CaseyJim:
   name: Jim Casey
   title: Assistant Professor of African American Studies, History, and English
   affiliation: The Pennsylvania State University
   website: https://jim-casey.com/
-vanhyningvictoriaanne:
-  name: Dr. Victoria Anne Van Hyning
+VanHyningVictoriaAnne:
+  name: Victoria Anne Van Hyning
   title: Assistant Professor of Library Innovation
   affiliation: University of Maryland, College of Information Studies
   orcid: 0000-0001-6775-2870
-jonesmasona:
+JonesMasonA:
   name: Mason A. Jones
   title: PhD Candidate
   affiliation: University of Maryland, College Park, iSchool
   orcid: 0000-0002-8777-2315
   website: https://masonajones.com
-dudleymatthew:
+DudleyMatthew:
   name: Matthew Dudley
   title: PhD Candidate
   affiliation: Yale University, Department of History
-readersteffy:
+ReaderSteffy:
   name: Steffy Reader
   title: Retired Psychotherapist
-blickhansamantha:
-  name: Dr. Samantha Blickhan
+BlickhanSamantha:
+  name: Samantha Blickhan
   title: Humanities Lead and Co-Director of the Zooniverse Team
   affiliation: The Adler Planetarium, Chicago IL
   orcid: 0000-0002-3775-5744
-grangerwill:
+GrangerWill:
   name: Will Granger
   title: Web Developer
   affiliation: Zooniverse, The Adler Planetarium, Chicago IL
-noordinshauna:
+NoordinShaunA:
   name: Shaun A. Noordin
   title: Web Developer
   affiliation: Zooniverse, The Adler Planetarium, Chicago IL
-rotherbecky:
+RotherBecky:
   name: Becky Rother
   title: Senior Product Designer
   affiliation: Devbridge
-koeserrebecca:
+KoeserRebeccaSutton:
   name: Rebecca Sutton Koeser
   title: Lead Developer
   affiliation: Center for Digital Humanities at Princeton
   orcid: 0000-0002-8762-8057
   website: https://rlskoeser.github.io/
-doroudiangissoo:
+DoroudianGissoo:
   name: Gissoo Doroudian
   title: User Experience Designer
   affiliation: Center for Digital Humanities at Princeton
   orcid: 0000-0002-6702-6964
   website: https://dynamicdor.com/
-budaknick:
+BudakNick:
   name: Nick Budak
   title: Digital Humanities Developer
   affiliation: Center for Digital Humanities at Princeton
   orcid: https://orcid.org/0000-0002-4542-0899
-lixinyi:
+LiXinyi:
   name: Xinyi Li
   title: Assistant Professor, Undergraduate Communications Design
   affiliation: Pratt Institute
   orcid: 0000-0002-6114-3182
-munsonrebecca:
+MunsonRebecca:
   name: Rebecca Munson
-  title: Assistant Director for Interdisciplinary Education 
+  title: Assistant Director for Interdisciplinary Education
   affiliation: Center for Digital Humanities at Princeton
   orcid: 0000-0002-8735-8405
-wythoffgrant:
+WythoffGrant:
   name: Grant Wythoff
   title: Digital Humanities Strategist
   affiliation: Center for Digital Humanities at Princeton

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -262,6 +262,27 @@ Either `pdf-img` or `youtube_id` should be specified.
 
 [view source](layouts/shortcodes/video.html)
 
+## Author metadata
+
+New authors should be added to the author data file with name, title, affiliation, and optional website URL and ORCID. Identifiers in the author data file should be in `PascalCase` based on last name first, so that names can be sorted based on those identifiers. Authors of articles and issue introductions should be listed in page metadata using the same identifier as the data file, for linking the content and displaying the author's name properly.  If an author's sort name cannot be programmatically determined from their display name, it should be set explicitly in the author data file.
+
+Example data file entry:
+```
+VanLastnameFirstname:
+  name: Firstname A. Lastname
+  sort_name: van Lastname, Firstname A.
+  title: Job title
+  affiliation: Example University
+  orcid: 0000-000X-XXXX-XXXX
+  website: https://example.org/profile
+```
+
+Example author metadata:
+```
+authors:
+    - LastnameFirstname
+```
+
 ## Generating PDFs
 
 PDF versions of feature articles should be created with [paged.js](https://pagedjs.org/) from the production site so that URLs are correct.

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -21,8 +21,18 @@
 <meta name="citation_title" content="{{ .Params.Title | htmlEscape }}"/>
 <meta name="citation_date" content="{{ .Params.date.Format `2006/01` }}"/>
 {{/* NOTE: Google Scholar prefers full date in YYYY/MM/DD form or year only */}}
+
+{{/* get author info from author data file */}}
+{{ $data := newScratch }} {{/* collect names for comma-delimited output */}}
 {{ range .Params.Authors }}
-<meta name="citation_author" content="{{ . }}"/>  {{/* lastname first preferred, if possible */}}
+    {{ $info := index $.Site.Data.authors . }} {{/* get author info */}}
+    {{ $lastname_first := partial "author_lastnamefirst.html" $info }}
+    {{/* add display name to author list for combined author metadata; use name from param as fallback if there is no entry in the authors data file */}}
+    {{ $data.Add "author_names" (slice ($info.name | default .)) }}
+<meta name="citation_author" content="{{ $lastname_first | default . }}"/>  {{/* lastname first preferred, if possible */}}
+{{- with $info.orcid -}}
+<meta name="citation_author_orcid" content="https://orcid.org/{{ . }}"/>
+{{- end -}}
 {{ end }}
 {{ with .Params.pdf -}}<meta name="citation_pdf_url" content="{{ . }}">{{- end }}
 {{ if .Params.doi }}<meta name="citation_doi" content="{{ .Params.doi }}"/>{{ end }}
@@ -33,7 +43,7 @@
 <meta name="citation_publisher" content="Center for Digital Humanities, Princeton University"/>
 <meta name="DC.rights" content="{{ .Site.Params.license }}" />
 {{/* metadata for PDF */}}
-<meta name="author" content="{{ delimit .Params.Authors ", " }}" />
+<meta name="author" content="{{ delimit ($data.Get "author_names") ", " }}" />
 <meta name="generator" content="Center for Digital Humanities, Princeton University"/>
 <meta name="dcterms.created" content="{{ .Params.date.Format `2006-01` }}"/>
 {{/* also available: dcterms.modified, keywords */}}

--- a/themes/startwords/layouts/partials/author_lastnamefirst.html
+++ b/themes/startwords/layouts/partials/author_lastnamefirst.html
@@ -1,13 +1,16 @@
-{{/* return sort name for an author; expects to be called with an author data file entry */}}
-{{/* if sort name is explicitly set in author metadata, use that */}}
-{{ $lastname_first := .sort_name }}
-{{/* otherwise generate from name */}}
-{{ if not .sort_name }}
-    {{ $nameParts := split .name " " }} {{/* split on spaces */}}
-    {{ $last := last 1 $nameParts }}{{/* assume last name is last word */}}
-    {{/* get all parts before the last */}}
-    {{ $first_parts := first (sub (len $nameParts) 1) $nameParts }}
-    {{/* combine last and then first name(s) */}}
-    {{ $lastname_first = delimit ((last 1 $nameParts) | append (delimit $first_parts " "))     ", " }}
-{{ end }}
+{{ $lastname_first := "" }}
+{{/* NOTE: build will fail if an author id doesn't match an author data record;
+    could check if . is set, but then will silently fail */}}
+    {{/* return sort name for an author; expects to be called with an author data file entry */}}
+    {{/* if sort name is explicitly set in author metadata, use that */}}
+        {{ $lastname_first = .sort_name }}
+    {{/* otherwise generate from name */}}
+    {{ if not .sort_name }}
+        {{ $nameParts := split .name " " }} {{/* split on spaces */}}
+        {{ $last := last 1 $nameParts }}{{/* assume last name is last word */}}
+        {{/* get all parts before the last */}}
+        {{ $first_parts := first (sub (len $nameParts) 1) $nameParts }}
+        {{/* combine last and then first name(s) */}}
+        {{ $lastname_first = delimit ((last 1 $nameParts) | append (delimit $first_parts " "))     ", " }}
+    {{ end }}
 {{ return $lastname_first }}

--- a/themes/startwords/layouts/partials/author_lastnamefirst.html
+++ b/themes/startwords/layouts/partials/author_lastnamefirst.html
@@ -1,0 +1,13 @@
+{{/* return sort name for an author; expects to be called with an author data file entry */}}
+{{/* if sort name is explicitly set in author metadata, use that */}}
+{{ $lastname_first := .sort_name }}
+{{/* otherwise generate from name */}}
+{{ if not .sort_name }}
+    {{ $nameParts := split .name " " }} {{/* split on spaces */}}
+    {{ $last := last 1 $nameParts }}{{/* assume last name is last word */}}
+    {{/* get all parts before the last */}}
+    {{ $first_parts := first (sub (len $nameParts) 1) $nameParts }}
+    {{/* combine last and then first name(s) */}}
+    {{ $lastname_first = delimit ((last 1 $nameParts) | append (delimit $first_parts " "))     ", " }}
+{{ end }}
+{{ return $lastname_first }}


### PR DESCRIPTION
in this pr:
- revise all author identifiers to use `PascalCase`
- update article metadata to use author names from data file
- new partial template to get author name in lastname, first format for article metadata
- document author data file in theme readme

to review:
- [x] check [authors page](https://startwords-dev-pr-291.onrender.com/authors/) to confirm all authors are correctly linked to their articles
- check author metadata in html header for at least one multi-author article:
  - [x] check `citation_author` — should have one for each author, in lastname first format
  - [x] check `citation_author_orcid` — should only be present if an ORCID is in the author data
  - [x] check `authors` — should be comma delimited list of all authors
- [x] test harvesting a citation with zotero to confirm the expected metadata comes through properly