### PR TITLE
pre-production config environment for producing pdfs

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -60,6 +60,7 @@ params:
     Humanities at Princeton.
   ISSN: 2694-2658
   googleSiteVerification: pS2kpksxg6JeC90IvA8BHVsFuK_6b7J_vARVLqqu7ck
+  absoluteArticleLinks: false
 
 defaultContentLang: en
 

--- a/config/pre-production/config.yaml
+++ b/config/pre-production/config.yaml
@@ -1,0 +1,3 @@
+# config to get production urls for generating PDFs
+params:
+  absoluteArticleLinks: true

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -297,6 +297,20 @@ Generate a PDF:
 pagedjs-cli https://startwords.cdh.princeton.edu/issues/1/their-data-ourselves/ -o startwords-1-their-data-ourselves.pdf
 ```
 
+### Generating PDFs for publication
+
+Build the site with the `pre-production` environment enabled (links to the official Startwords site instead of local development site):
+```
+hugo --environment pre-production
+```
+
+Serve out the built static site so that you can access it locally, e.g. using python:
+```
+python3 -m http-server --directory public
+```
+
+Review the site locally and then generate PDFs as documented.
+
 ## Customizing shape of preview text for article hook on issue list and home page
 
 By default, the height of the shaping element is determined by the length of the content of the summary as plain text.  If you need to override this for an article where the calculation does not work, you can specify `hook_height_override` as a parameter on the article. This should be the desired height of the shaping element on mobile in pixels (provide the numerical value only).

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -306,7 +306,7 @@ hugo --environment pre-production
 
 Serve out the built static site so that you can access it locally, e.g. using python:
 ```
-python3 -m http-server --directory public
+python3 -m http.server --directory public
 ```
 
 Review the site locally and then generate PDFs as documented.

--- a/themes/startwords/layouts/article/single.html
+++ b/themes/startwords/layouts/article/single.html
@@ -17,7 +17,7 @@
 
 {{ define "page_meta" }}
 <link rel="schema.DC" href="http://purl.org/DC/elements/1.0/"/>
-<meta name="citation_public_url" content="{{ .RelPermalink | absURL }}" />
+<meta name="citation_public_url" content="{{ cond .Site.Params.absoluteArticleLinks .Permalink .RelPermalink | absURL }}" />
 <meta name="citation_title" content="{{ .Params.Title | htmlEscape }}"/>
 <meta name="citation_date" content="{{ .Params.date.Format `2006/01` }}"/>
 {{/* NOTE: Google Scholar prefers full date in YYYY/MM/DD form or year only */}}
@@ -56,7 +56,7 @@
     <article {{ with .Params.article_class }} class="{{ . }}" {{ end }}>
         <div class="grid">
             <header>
-                <p class="number"><a href="{{ .Parent.RelPermalink }}">{{ i18n "issue" }} {{ .Parent.Params.number }}</a></p>
+                <p class="number"><a href="{{ cond .Site.Params.absoluteArticleLinks .Parent.Permalink  .Parent.RelPermalink }}">{{ i18n "issue" }} {{ .Parent.Params.number }}</a></p>
                 <p class="theme">{{ .Parent.Params.theme }}</p>
                 <h1>{{ .Params.Title }}</h1>
                 <p>{{ partial "authors" . }}</p>
@@ -76,7 +76,7 @@
                 {{ end }}
                 <p class="formats">
                 {{ with  .OutputFormats.Get "txt" -}}
-                    <a href="{{ .RelPermalink }}" rel="alternate" type="text/plain">TXT</a>
+                    <a href="{{ cond $.Site.Params.absoluteArticleLinks .Permalink .RelPermalink }}" rel="alternate" type="text/plain">TXT</a>
                 {{- end }}
                 {{ with .Params.pdf -}}
                     <a href="{{ . }}" rel="alternate" type="application/pdf">PDF</a>
@@ -88,11 +88,11 @@
 
             {{/* elements for PDF header & footer */}}
             <section class='print-only'>
-
-                <a class="first-page-header" href="{{ relURL "/" }}" aria-label="Startwords">
+                {{ $siteUrl := cond .Site.Params.absoluteArticleLinks (absURL "/") (relURL "/") }}
+                <a class="first-page-header" href="{{ $siteUrl }}" aria-label="Startwords">
                     <img alt="Startwords" src="{{ relURL "/pdf-logotype.svg" }}" /></a>
 
-                <a class="page-header" href="{{ relURL "/" }}" aria-label="Startwords">
+                <a class="page-header" href="{{ $siteUrl }}" aria-label="Startwords">
                     <img alt="Startwords" src="{{ relURL "/pdf-logo.svg" }}" /></a>
 
                  <a href="http://doi.org/{{ .Params.doi }}" rel="alternate" class="page-doi">doi:{{ .Params.doi }}</a>

--- a/themes/startwords/layouts/partials/authors.html
+++ b/themes/startwords/layouts/partials/authors.html
@@ -2,6 +2,7 @@
     {{ range .Params.Authors }}
     {{ $info := index $.Site.Data.authors . }} {{/* get author info */}}
     {{/* display name from param as fallback if there is no entry in the authors data file */}}
-    <li><address>{{ $info.name | default . }}</address>{{ if $info }}<a href="{{ relURL "/authors/" }}#{{ . }}" aria-label="author info" title="author info"><i class="ph-link-thin"></i></a>{{ end }}</li>
+    {{ $authorsUrl := cond $.Site.Params.absoluteArticleLinks (absURL "/authors/") (relURL "/authors/") }}
+    <li><address>{{ $info.name | default . }}</address>{{ if $info }}<a href="{{ $authorsUrl }}#{{ . }}" aria-label="author info" title="author info"><i class="ph-link-thin"></i></a>{{ end }}</li>
     {{ end }}
 </ul>


### PR DESCRIPTION
in this pr:
- re-organize config file into config dir structure
- add pre-production config environment
- add new `absoluteArticleLinks` config setting, off by default
- use `absoluteArticleLinks` to generate relative or absolute links in article html template for links used in pdf
- document how to build site in pre-production mode to generate production PDFs

to review:
- [x] look over config and template changes
- [x] review new readme documentation for pdf generation
- [x] check render site article display to make sure nothing has been broken, links are relative
- [x] look at [test pdf](https://drive.google.com/file/d/1nHVBZcSpp-ykI9tgxs_ACopHEgVXhJBA/view?usp=sharing) generated in this way; confirm that all startwords links (issue, startwords header links, author info link) take you to the startwords production site
