### PR TITLE
Update keyboards piece to provide access to code within the article

### DIFF
--- a/content/issues/2/strangers-in-the-landscape/index.md
+++ b/content/issues/2/strangers-in-the-landscape/index.md
@@ -37,6 +37,8 @@ Let's start by setting up a very basic web form. It has one text input field, on
 
 <iframe title="Basic Input Form" id="kb-s01" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-01.html"></iframe>
 
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-01.html" format="html" >}}
+
 Everything we build from this point onwards is meant to solve one very simple problem: **how do we allow users to type, into that text input field, in a language that's not native to their keyboard?** For example, how do we help a user type in the text "ごはんを食べる" when they only have a US-International QWERTY keyboard, and we don’t want to ask them to futz about in their computer settings to install a Japanese language pack?
 
 {{< wrap class="print-only-preview" >}}
@@ -71,14 +73,13 @@ A straightforward solution is to create an on-screen keyboard for the user. In t
 *Note: we’re using the Japanese hiragana characters あいうえお here because they map easily to the English characters AIUEO, and are written left to right. We’ll build up to more complex alphabets, such as Hebrew and its right-to-left layout, in later sections.*
 
 <iframe title="Simple On-screen Keyboard" id="kb-s02" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-02.html"></iframe>
-
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-02.html" format="html" >}}
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
 | INTERACTIVE COMPONENT.
 | SOURCE CODE: https://github.com/shaunanoordin/zooniverse-startwords/blob/master/section-02.html
 ⩩-----------------------------------------------------------------------------------⟩
 {{</ wrap >}}
-
 
 The code here is simple, but we already come across a problem: what if the user wants to add a Japanese character in the middle (instead of at the end) of the text box? This is, after all, a very basic function for a normal text box—you can place the text cursor/caret at any part of the existing text and then start typing.
 
@@ -98,6 +99,7 @@ During the brainstorming process for *Scribes*, we discussed how the *Ancient Li
 This is actually a solved problem: we use the standard `HTMLInputElement`’s `selectionStart`, `selectionEnd`, and `setSelectionRange` to interact with the “text cursor” on the text input field.
 
 <iframe title="Text Selection Feature" id="kb-s03" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-03.html"></iframe>
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-03.html" format="html" >}}
 
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
@@ -109,7 +111,6 @@ This is actually a solved problem: we use the standard `HTMLInputElement`’s `s
 In the example above, we’ve done two things in the code: 1. we ensure the Japanese characters are inserted at the position of the text cursor/caret, and 2. we ensure the text input maintains focus after the insertion. These may seem like minor coding considerations, but they’re important to **ensure a consistent User Experience (UX), since users often have pre-set expectations on how User Interface (UI) elements should behave.**
 
 {{</ wrap >}}
-
 
 Based on institutional knowledge—held by our Zooniverse colleagues who built the *Ancient Lives* project—and early technical experiments, we knew that a basic version of the clickable keyboard feature would be technically feasible to create. However, the breadth of scripts, languages, layouts, and physical deterioration among the vast Geniza corpus meant that there would be varying levels of difficulty in the fragments’ transcription. To be immediately presented with a random Geniza fragment and asked to transcribe it would be overwhelming for most users. To that end, we considered ways to harness existing information about the fragments (metadata) to break down the corpus into smaller groups. The problem with this approach was that the fragments came from multiple institutions, each with its own metadata system. Some of those systems were more robust (and more recently updated) than others.
 
@@ -141,6 +142,8 @@ Alright, so we now have an on-screen keyboard. But what about the user’s physi
 In this example, when the user presses the "A" key on their keyboard, the Japanese character あ is inserted into the text field instead. Same for the other characters: A -> あ , I -> い, U -> う, E -> え, O -> お
 
 <iframe title="Keyboard Key Capture" id="kb-s04" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-04.html"></iframe>
+
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-04.html" format="html" >}}
 
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
@@ -198,6 +201,8 @@ In the example below, you won’t see many changes in terms of UI functionality,
 
 <iframe title="Full Keyboard Implementation" id="kb-s05" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-05.html"></iframe>
 
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-05.html" format="html" >}}
+
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
 | INTERACTIVE COMPONENT.
@@ -231,6 +236,8 @@ Now that we have cleaned up the code so that the English and Japanese keyboards 
 To illustrate this point, we’ve added a joke "Emoji keyboard" that maps QWERTY keys to arbitrary emoji characters. Typing in “Hello world” into input text field will result in the emoji “text” of “🐟🤣🦋🦋😍 😅😍🥰🦋🐒.”
 
 <iframe title="Emoji Keyboard" id="kb-s06" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-06.html" class="force-page-break"></iframe>
+
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-06.html" format="html" >}}
 
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
@@ -268,6 +275,8 @@ As a result, we must be conscientious when we create on-screen keyboards for lan
 * The text input field has an explicit CSS direction value that changes depending on the active keyboard.
 
 <iframe title="Hebrew, English, and Emoji Keyboard" id="kb-s07" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-07.html"></iframe>
+
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-07.html" format="html" >}}
 
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
@@ -334,6 +343,8 @@ In our example below, we’ve added the “Yemenite Square” visual script refe
 
 <iframe title="Keyboard with Script Images" id="kb-s08" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-08.html"></iframe>
 
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-08.html" format="html" >}}
+
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩
 | INTERACTIVE COMPONENT.
@@ -376,6 +387,7 @@ There are several advantages to organising our "Yemenite Square" Hebrew script i
 In the example below, you’ll see that we’ve added **six new Hebrew scripts,** and if you check the code, doing so only required six additional lines of code.
 
 <iframe title="Keyboard with Multiple Script Images" id="kb-s09" src="/issues/2/strangers-in-the-landscape/zooniverse-interludes/section-09.html"></iframe>
+{{< source_code source_file="issues/2/strangers-in-the-landscape/zooniverse-interludes/section-09.html" format="html" >}}
 
 {{< wrap class="txt-only" >}}
 ⩩-----------------------------------------------------------------------------------⟩

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -262,6 +262,18 @@ Either `pdf-img` or `youtube_id` should be specified.
 
 [view source](layouts/shortcodes/video.html)
 
+### source code
+
+Use to display highlighted source code from a file in a details/summary element.
+Path should be relative to content directory.
+
+Example use:
+```
+{{< source_code source_file="path/to/code.html" format="html" >}}
+```
+
+[view source](layouts/shortcodes/source_code.html)
+
 ## Author metadata
 
 New authors should be added to the author data file with name, title, affiliation, and optional website URL and ORCID. Identifiers in the author data file should be in `PascalCase` based on last name first, so that names can be sorted based on those identifiers. Authors of articles and issue introductions should be listed in page metadata using the same identifier as the data file, for linking the content and displaying the author's name properly.  If an author's sort name cannot be programmatically determined from their display name, it should be set explicitly in the author data file.

--- a/themes/startwords/assets/scss/article/_figure.scss
+++ b/themes/startwords/assets/scss/article/_figure.scss
@@ -34,7 +34,14 @@ figure {
 }
 
 pre {
-    margin: rem(30px) auto;
-    max-width: 75%;
+    margin: 0;
+    /* compensate for interlude margins */
+    margin-left: -10px;
+    padding-left: 10px;
     white-space: pre-wrap;
+
+    @media (min-width: $breakpoint-s) {
+        margin: rem(30px) auto;
+        max-width: 75%;
+    }
 }

--- a/themes/startwords/assets/scss/article/_interlude.scss
+++ b/themes/startwords/assets/scss/article/_interlude.scss
@@ -21,7 +21,7 @@
         top: 0;
         left: -10px;
         height: 100%;
-        background: #4C2A85;
+        background: $purple;
         /*opacity: 0.5; /* for testing */
 
         @media (min-width: $breakpoint-s) {

--- a/themes/startwords/assets/scss/article/_single.scss
+++ b/themes/startwords/assets/scss/article/_single.scss
@@ -269,6 +269,35 @@ body.article article, body.page article {
     }
 }
 
+details.code {
+    margin-bottom: rem(22px);
+    background-color: #272822;  // match code background color
+    summary {
+        // match background when closed
+        background-color: $off-white;
+        .interlude & {
+            background-color: $purple;
+        }
+        text-align: center;
+        font-style: italic;
+    }
+
+    &[open] {
+        // full width on mobile
+        margin-left: -10px;
+        padding-left: 10px;
+        @media (min-width: $breakpoint-s) {
+            margin-left: auto;
+            padding-left: auto;
+        }
+
+        summary {
+        // match code background when open
+        background-color: #272822;
+        }
+    }
+}
+
 /* fallback content included to be shown in TXT version only */
 .txt-only {
     display: none;

--- a/themes/startwords/layouts/shortcodes/source_code.html
+++ b/themes/startwords/layouts/shortcodes/source_code.html
@@ -1,0 +1,6 @@
+<details class="code">
+    <summary>view source code</summary>
+    <pre>
+    {{ highlight (os.ReadFile (.Get "source_file")) (.Get "format" ) }}
+    </pre>
+</details>


### PR DESCRIPTION
We've talked about startwords pieces including code snippets, but the one piece we've published so far that was technical enough to do so, we don't show the code! I think we should make the code more easily available in the article, since people will be much more likely to look at it there (vs. at least two clicks otherwise).

in this pr:
- new short code (& accompanying styles) for displaying code from a file in a collapsed details/summary element
- document the short code in theme readme
- use the new short code to embed a viewable version of the source code in the keyboards article for each embedded keyboard

----- 

to review:
- [x] review the file changes in this pr
- [x] look at the article with code embedded in the piece on render site: https://startwords-dev-pr-300.onrender.com/issues/2/strangers-in-the-landscape/
