### PR TITLE
Tweak author list translator styles for mobile

### DIFF
--- a/themes/startwords/assets/scss/authors/_list.scss
+++ b/themes/startwords/assets/scss/authors/_list.scss
@@ -79,9 +79,22 @@ body.authors {
                 color: $dark-grey;
             }
         }
+
         /* when an item has both co-authors and translators, separate */
-        .coauthors + .translators:not(:empty)::before {
-            content: "; "
+        .coauthors + .translators:not(:empty) {
+            // put translators on second line on mobile
+            display: block;
+
+            @media (min-width: $breakpoint-s) {
+                display: inline;
+            }
+
+            &::before {
+                // on desktop, add a semicolon to separate since it doesn't wrap
+                @media (min-width: $breakpoint-s) {
+                    content: "; "
+                }
+            }
         }
 
         .translators:empty {


### PR DESCRIPTION
adjusted translator styles for mobile: force it to always be on a newline, don't display the semicolon.


review PR author page: https://startwords-dev-pr-306.onrender.com/authors/

(FYI, I think we'll need to revisit this once we have content with more than one translation)