### PR TITLE
Include issue publication date on single issue and home page

### DIFF
--- a/themes/startwords/assets/scss/issue/_list.scss
+++ b/themes/startwords/assets/scss/issue/_list.scss
@@ -11,7 +11,6 @@ body.issue-list {
         }
 
         .number { font-weight: bold; }
-        .pubdate { font-weight: 400; }
 
         .theme {
             font-weight: 900;

--- a/themes/startwords/assets/scss/issue/_single.scss
+++ b/themes/startwords/assets/scss/issue/_single.scss
@@ -14,6 +14,8 @@ body.issue {
         padding-top: rem(45px);
         min-height: 100vh;
 
+        .pubdate { font-weight: 400; }
+
         // summary is a <div> containing rich text here
         .summary {
             margin: 0;

--- a/themes/startwords/assets/scss/issue/_summary.scss
+++ b/themes/startwords/assets/scss/issue/_summary.scss
@@ -41,6 +41,7 @@
     
     .pubdate {
         font-size: rem(16px);
+        font-weight: 400;
     }
 
     .summary {

--- a/themes/startwords/assets/scss/issue/_summary.scss
+++ b/themes/startwords/assets/scss/issue/_summary.scss
@@ -38,6 +38,10 @@
         margin-left: 0;
         font-weight: 300;
     }
+    
+    .pubdate {
+        font-size: rem(16px);
+    }
 
     .summary {
         margin: rem(10px) 0 0;

--- a/themes/startwords/layouts/index.html
+++ b/themes/startwords/layouts/index.html
@@ -20,6 +20,7 @@
             {{ $issues := where .Site.Pages "Type" "issue" | lang.Merge (where .Site.AllPages "Type" "issue") }}
             {{ $issue := index ($issues) 0 }}
             <span class="number">{{ i18n "issue" }} {{ $issue.Params.number }}</span>
+            {{ partial "pubdate" $issue }}
             <h2 class="theme">{{ $issue.Params.theme }}</h2>
             <p class="summary">
                 {{ $issue.Summary | plainify }}

--- a/themes/startwords/layouts/issue/single.html
+++ b/themes/startwords/layouts/issue/single.html
@@ -11,6 +11,7 @@
     <div class="issue-summary grid">
         <div class="container">
             <span class="number">{{ i18n "issue" }} {{ .Params.number }}</span>
+            {{ partial "pubdate" . }}
             <h1 class="theme">{{ .Params.theme }}</h1>
             <div class="summary">
                 {{ .Content }}


### PR DESCRIPTION
fixes #309

- adds issue publication date to homepage issue display
- adds issue publication date to single issue page 

uses / adapts existing text styles for publication date

