### PR TITLE
Limit deep zoom height on mobile to avoid scroll traps #323

### DIFF
--- a/themes/startwords/assets/scss/article/_single.scss
+++ b/themes/startwords/assets/scss/article/_single.scss
@@ -234,6 +234,11 @@ body.article article, body.page article {
 
     .deepzoom {
         width: 100%;
+        /* limit height to avoid scroll traps on mobile */
+        max-height: 50vh;
+        @media (min-width: $breakpoint-xs) {
+            max-height: auto;
+        }
     }
 
     .video-embed-wrapper {


### PR DESCRIPTION
added a max height of 50% of the screen (50vh) to deep zoom on mobile to prevent scroll traps