### PR TITLE
Make body text font-weight 400, not 300

### DIFF
--- a/themes/startwords/assets/scss/_fonts.scss
+++ b/themes/startwords/assets/scss/_fonts.scss
@@ -121,7 +121,4 @@
     // harmonize sizing with font for Latin characters
     // on desktop, main font should be 18px and Noto Serif TC should be 16px
     size-adjust: 89%;
-    // we're using regular font weight (400), but want it displayed
-    // with the main body text, which as currently font-weight 300
-    font-weight: 300;
 }

--- a/themes/startwords/assets/scss/_global.scss
+++ b/themes/startwords/assets/scss/_global.scss
@@ -47,5 +47,5 @@ dd {
 /* Use Noto Serif TC for anything explicitly labeled as Chinese language */
 *[lang=zh] {
     font-family: "Noto Serif TC";
-    font-weight: 300;
+    font-weight: 400;
 }

--- a/themes/startwords/assets/scss/article/_interlude.scss
+++ b/themes/startwords/assets/scss/article/_interlude.scss
@@ -8,7 +8,7 @@
     padding: 35px 0;
 
     color: #E0CEFF;
-    font-weight: 300;
+    font-weight: 400;
     font-size: 16px;
     font-family: 'IBM Plex Serif', 'Palatino', serif;
 

--- a/themes/startwords/assets/scss/article/_single.scss
+++ b/themes/startwords/assets/scss/article/_single.scss
@@ -22,6 +22,7 @@ body.article {
             }
 
             .number {
+                font-weight: 300;
                 a, a:visited {
                     color: $dark-grey;
                     text-decoration: none;
@@ -96,14 +97,14 @@ body.article article, body.page article {
             padding-bottom: 3px; // space for underlines at end of paragraph
             margin-top: rem(17px);
             margin-bottom: rem(17px);
-            font-weight: 300;
+            font-weight: 400;
             line-height: rem(27px);
             @media (min-width: $breakpoint-m) { line-height: rem(30px); }
         }
 
         // lists
         ol, ul {
-            font-weight: 300;
+            font-weight: 400;
             line-height: rem(27px);
         }
 
@@ -129,7 +130,7 @@ body.article article, body.page article {
                 caption-side: bottom;
                 font-family: $font-serif;
                 font-style: italic;
-                font-weight: 300;
+                font-weight: 400;
                 line-height: 30px;
                 padding-top: 1.5rem;
                 padding-bottom: 1rem;
@@ -147,14 +148,14 @@ body.article article, body.page article {
             p {
                 margin: 0;
                 font-style: italic;
-                font-weight: 300;
+                font-weight: 400;
             }
 
             cite {
                 display: block;
                 margin-top: rem(5px);
                 font-style: normal;
-                font-weight: 300;
+                font-weight: 400;
 
                 &::before {
                     content: ' – '

--- a/themes/startwords/assets/scss/print.scss
+++ b/themes/startwords/assets/scss/print.scss
@@ -7,7 +7,7 @@
 
   @top-left {
     content: string(title);
-    font-weight: 300;
+    font-weight: 400;
     font-size: 11px;
     font-family: $font-serif;
   }
@@ -21,14 +21,14 @@
     content: element(page-footer);
     opacity: 1;
     font-size: 11px;
-    font-weight: 300;
+    font-weight: 400;
   }
 
 
   @bottom-right {
     content: counter(page);
     font-size: 11px;
-    font-weight: 300;
+    font-weight: 400;
   }
 }
 
@@ -75,7 +75,7 @@ body {
             }
 
             .authors {
-                font-weight: 300;
+                font-weight: 400;
             }
 
             .theme {


### PR DESCRIPTION
Currently, the body text of _Startwords_ is set to a font weight of 300. This looks a little spindly and light, and is difficult to read for extended passages of text. Most body text on the web is set to 400, which is the OpenType specification for "normal / regular" text. (300 is light, 500 medium, 700 bold, etc.)

As discussed with @rlskoeser, who recalled that @gissoo's original designs set body text at 400, this change would bump up all body text to 400. Other bits of text are retained at 300 as originally intended for emphasis and variation (like in the metadata block at the top of articles).

@rlskoeser if you still agree with this change, please verify that this PR addresses every place that body text was set to 300, and that you approve how the new body text looks in articles.