### PR TITLE
Add & document theme word wrap override parameter #341

### DIFF
--- a/content/issues/4/_index.md
+++ b/content/issues/4/_index.md
@@ -4,6 +4,7 @@ layout: single
 title: Issue 4
 number: 4
 theme: PALIMPSESTS
+theme_wrap_width: 8rem
 date: 2023-08-29 # Change me
 slug: 4
 num_features: 2

--- a/themes/startwords/README.md
+++ b/themes/startwords/README.md
@@ -69,6 +69,8 @@ hugo new --kind issue issues/4
 
 In `content/issues/4/_index.md` file, you'll then need to set metadata like `theme` and `contributors`.
 
+Issue theme words are automatically wrapped on the issue list page unless they are under less than 7 characters long. To override the default wrap width, use `theme_wrap_width`; it is recommended to set the wrap width in rem.
+
 You should also add the name(s) of the authors of the issue introduction in two places: first, add that name as an entry in `data/authors.yml`. Second, add the LastnameFirstname slug of that author or authors into the metadata of the `content/issues/4/_index.md` file.
 
 And to draft a new article named "A Cup of Tea", run these commands, again at the project's top-level directory:

--- a/themes/startwords/archetypes/issue/_index.md
+++ b/themes/startwords/archetypes/issue/_index.md
@@ -4,6 +4,7 @@ layout: single
 title: Issue {{ .Name }}
 number: {{ .Name }}
 theme: INSERT_THEME
+theme_wrap_width: # optional override for theme word width on issue list; specify in rem
 # Unless the publish date is before today's date, hugo won't publish it.
 date: {{ now.Format "2006-01-02" }} # Change me
 slug: {{ .Name }}

--- a/themes/startwords/layouts/issue/summary.html
+++ b/themes/startwords/layouts/issue/summary.html
@@ -1,5 +1,6 @@
 <article class="issue-summary">
     <p class="number">{{ i18n "issue" }} {{ .Params.number }}</p>
     {{ partial "pubdate" . }}
-    <h2 class="theme {{ if le (len .Params.theme) 7 }}no-wrap{{end}}">{{ .Params.theme }}</h2>
+    <h2 class="theme {{ if le (len .Params.theme) 7 }}no-wrap{{ end }}"
+    {{ with .Params.theme_wrap_width }}style="width: {{ . }}"{{ end }}>{{ .Params.theme }}</h2>
 </article>


### PR DESCRIPTION
- adds a new optional parameter to override theme wrapping width
- add new parameter and document in issue index archetype template
- document the new parameter in theme readme
- use the new parameter for issue 4