### PR TITLE
Fix spacing for homepage issue with 2 feature articles #343

### DIFF
--- a/themes/startwords/assets/scss/_home.scss
+++ b/themes/startwords/assets/scss/_home.scss
@@ -20,8 +20,14 @@
     }
 
     #features {
-        padding-top: 0;
+        padding-top: rem(22px);
         padding-bottom: rem(50px);
+        @media (min-width: $breakpoint-m) {
+            padding-top: rem(28px);
+        }
+        @media (min-width: $breakpoint-l) {
+            padding-top: rem(62px);
+        }
     }
 
     main > .content {

--- a/themes/startwords/assets/scss/article/_summary.scss
+++ b/themes/startwords/assets/scss/article/_summary.scss
@@ -200,10 +200,6 @@ $preview-height-xl: rem(250px);  // 1024px-
         }
     }
 
-    // adjust spacing for first summary when there are three
-    &:nth-of-type(1):nth-last-of-type(3) {
-        margin-top: rem(62px);
-    }
     /* add spacing to any summary that comes after the first in a column */
     &:nth-child(n+3) {
         margin-top: rem(96px);


### PR DESCRIPTION
I think the padding was being applied in the wrong place and conditionally when it shouldn't have. I think it works correctly now for both 2 and 3 articles. Feel free to pull locally and toggle the `num_features` setting or publication date of issue 4 if you want to check. 

Please review homepage and single issue pages for issues with 2 and 3 features.