### PR TITLE
Update figure 6 based on Gian's notes

### DIFF
--- a/content/issues/4/unnatural-language/index.md
+++ b/content/issues/4/unnatural-language/index.md
@@ -376,18 +376,20 @@ While earlier dictionaries primarily glossed glyphs by providing similar-soundin
   <aside class="card">
   <header>Say <em>east</em> in Middle Chinese</header>
   
-  <p class="large"><span class="tek">東</span> /tuŋ/</p>
-  <p class="large"><span class="tek">德 +</span> 紅 = 東</p>
+  <p class="large"><span class="tek" lang="zh">東</span> tuwŋ</p>
+  <p class="large"><span class="tek"><span lang="zh">德</span> +</span> <span lang="zh">紅</span> = <span lang="zh">東</span></p>
 
-  <p><span class="tek">/t<span class="fade">ək</span>/</span>  /<span class="fade">ɣ</span>uŋ/</p>
+  <p><span class="tek">t<span class="fade">ok</span></span>  <span class="fade">h</span>uwŋ</p>
   </aside>
   
   <aside class="card">
     <header>Say <em>fight</em> in English</header>
     <p class="large"><span class="fish">Fight</span> /fʌɪt/</p>
     <p class="large"><span class="fish">Fish +</span> light = fight</p>
-    <p><span class="fish">/fɪ<span class="fade">ʃ</span>/</span>
-     /<span class="fade">l</span>ʌɪt/</span></p>
+    <p>
+      <span class="fish">/f<span class="fade">ɪʃ</span>/</span>
+     /<span class="fade">l</span>ʌɪt/</span>
+    </p>
   </aside>
 
   <p class="caption"><b>Figure 6.</b> How the <em>fanqie</em> pronunciation system works</p>


### PR DESCRIPTION
* Don't use IPA slashes for Middle Chinese
* Use Baxter's transcription system
* Fix the highlighting on "fish"
* Indicate language on spans to fix font usage

We might want to revisit the faded highlights on the transcriptions...it's kind of hard to tell which thing is being highlighted, especially because the font that gets used to render IPA characters looks bolder than the regular one:

<img width="70" alt="Screenshot 2023-09-16 at 15 20 00" src="https://github.com/Princeton-CDH/startwords/assets/4924494/fc517767-7b9e-4ee6-9312-dc2916130e41">
