### PR TITLE
Add a shadow to the deep zoomable viewer

### DIFF
--- a/themes/startwords/assets/scss/article/_single.scss
+++ b/themes/startwords/assets/scss/article/_single.scss
@@ -234,6 +234,8 @@ body.article article, body.page article {
 
     .deepzoom {
         width: 100%;
+        box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+
         /* limit height to avoid scroll traps on mobile */
         max-height: 50vh;
         @media (min-width: $breakpoint-xs) {


### PR DESCRIPTION
I was noticing that it was hard to determine where the borders of the zoomable viewer were when the image had a lot of white in the background. This just adds a simple box-shadow to make it "pop" a bit more. Just a suggestion 🤷🏻 

<img width="1161" alt="Screenshot 2023-09-16 at 15 25 50" src="https://github.com/Princeton-CDH/startwords/assets/4924494/66def229-9288-4172-b33b-2303193a1281">

<img width="1307" alt="Screenshot 2023-09-16 at 15 24 33" src="https://github.com/Princeton-CDH/startwords/assets/4924494/062dd6ca-a81a-49cf-8385-67c9648cffde">
