### PR TITLE
Invert colors for author link icon visibility in dark mode

### DIFF
--- a/themes/startwords/assets/scss/_darkmode.scss
+++ b/themes/startwords/assets/scss/_darkmode.scss
@@ -16,6 +16,11 @@
         .theme {
             color: $light-purple;
         }
+        /* the link icon for author info is dark;
+           invert for dark mode so it will be visible */
+        .authors i[class^="ph-link"] {
+            filter: invert(1);
+        }
     }
 
     .tags {


### PR DESCRIPTION
fixes #358

review: https://startwords-dev-pr-359.onrender.com/issues/1/weaving-as-interface/