### PR TITLE
Use serif font style for large Chinese text in all figures

### DIFF
--- a/content/issues/4/sonorous-medieval/style.css
+++ b/content/issues/4/sonorous-medieval/style.css
@@ -56,6 +56,10 @@ cite.book::before {
   width: auto;
 }
 
+#fig2 *[lang=zh] {
+  font-family: var(--font-serif);
+}
+
 /* figure two table needs side-scrolling on mobile,
   but does not need wider margins */
 #fig2 table.side-scroll {
@@ -513,6 +517,7 @@ button.play:hover:after {
 
 #fig7 .source {
   text-decoration: none;
+  font-family: var(--font-serif);
 }
 
 #fig7 .notes::after {


### PR DESCRIPTION
This updates figures 2 and 7 to use serif fonts for large characters.
