### PR TITLE
Add plausible analytics template and configuration

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -60,6 +60,11 @@ params:
   ISSN: 2694-2658
   googleSiteVerification: pS2kpksxg6JeC90IvA8BHVsFuK_6b7J_vARVLqqu7ck
   absoluteArticleLinks: false
+  plausible:
+    domain: startwords.cdh.princeton.edu
+    script: https://plausible.io/js/script.file-downloads.hash.outbound-links.js
+    notfound: true
+
 
 defaultContentLang: en
 

--- a/themes/startwords/layouts/_default/baseof.html
+++ b/themes/startwords/layouts/_default/baseof.html
@@ -73,6 +73,7 @@
     <script defer src="{{ $js.RelPermalink }}"></script>
     {{- if hugo.IsProduction -}}
     {{ partial "partials/google_analytics.html" . }}
+    {{ partial "partials/plausible_analytics.html" . }}
     {{- end -}}
     {{- if or (.HasShortcode "deepzoom") (isset .Page.Params "needs_deepzoom") }}{{/* include openseadragon when deepzoom shortcode is used or requested in page params */}}
     <script defer src="https://cdn.jsdelivr.net/npm/openseadragon@2.4.2/build/openseadragon/openseadragon.min.js" integrity="sha256-NMxPj6Qf1CWCzNQfKoFU8Jx18ToY4OWgnUO1cJWTWuw=" crossorigin="anonymous"></script>

--- a/themes/startwords/layouts/partials/plausible_analytics.html
+++ b/themes/startwords/layouts/partials/plausible_analytics.html
@@ -1,0 +1,7 @@
+{{- if isset site.Params "plausible" }}
+{{/* plausible analytics */}}
+<script defer data-domain="{{ site.Params.plausible.domain }}" src="{{ site.Params.plausible.script }} "></script>
+{{- if isset site.Params.plausible "notfound" }}
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR adds a template and config for Plausible analytics tracking, so we can make a more informed decision about switching from Google Analytics to Plausible. This structured the same way we added it to CDH django applications, with intentionally minimal configuration.

FWIW I saw some warnings / errors on the google analytics template when I was testing this, hopefully something out of date on my side that you've already dealt with for the new issue.